### PR TITLE
Update precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: check-added-large-files
   - id: check-ast
@@ -19,29 +19,25 @@ repos:
   - id: mixed-line-ending
   - id: requirements-txt-fixer
   - id: trailing-whitespace
-- repo: https://github.com/keewis/blackdoc
-  rev: v0.3.9
-  hooks:
-  - id: blackdoc
-    additional_dependencies: [black==23.11.0]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.5
+  rev: v0.16.2
   hooks:
-  - id: ruff
+  - id: ruff-check
     args: [--fix, --show-fixes]
   - id: ruff-format
 - repo: https://github.com/executablebooks/mdformat
-  rev: 0.7.22
+  rev: 1.0.0
   hooks:
   - id: mdformat
+    additional_dependencies: [mdformat-ruff]
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.14.0
+  rev: v2.16.0
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --preserve-quotes]
   - id: pretty-format-toml
     args: [--autofix]
 - repo: https://github.com/gitleaks/gitleaks
-  rev: v8.23.3
+  rev: v8.30.0
   hooks:
   - id: gitleaks

--- a/bench/ANALYTIC_RECURSION_2026-08-01.md
+++ b/bench/ANALYTIC_RECURSION_2026-08-01.md
@@ -104,7 +104,9 @@ how `d/dT` is evaluated:
 
 ```python
 negT, posT = T - 0.5, T + 0.5
-return Q(..., s - 1, T) + T / (s + 1) * (Q(..., s - 1, posT) - Q(..., s - 1, negT))
+return Q(..., s - 1, T) + T / (s + 1) * (
+    Q(..., s - 1, posT) - Q(..., s - 1, negT)
+)
 ```
 
 Note there is no division by the step: the +/-0.5 is chosen so that

--- a/bench/CODE_REVIEW_2026-08-01.md
+++ b/bench/CODE_REVIEW_2026-08-01.md
@@ -38,7 +38,9 @@ inside a double loop — 256 solves for a 16-species mixture:
 ```python
 for i in range(nb_species):
     for j in range(nb_species):
-        dij = np.array([delta(h, i) - delta(h, j) for h in range(0, nb_species)])
+        dij = np.array(
+            [delta(h, i) - delta(h, j) for h in range(0, nb_species)]
+        )
         b_vec[:nb_species] = 3 * np.sqrt(np.pi) * dij
         cflat = scl.lu_solve(lu_piv_q, b_vec)
 ```
@@ -50,8 +52,8 @@ nb_species unit vectors gives everything:
 ```python
 B = np.zeros((4 * nb, nb))
 B[:nb, :] = 3 * np.sqrt(np.pi) * np.eye(nb)
-X = scl.lu_solve(lu_piv_q, B)          # one call, nb right-hand sides
-c0 = np.diag(X[:nb])[:, None] - X[:nb] # c^{ji}_{i0} for every (i, j)
+X = scl.lu_solve(lu_piv_q, B)  # one call, nb right-hand sides
+c0 = np.diag(X[:nb])[:, None] - X[:nb]  # c^{ji}_{i0} for every (i, j)
 ```
 
 Verified equal to 8e-16 at T = 2000/8000/12000/20000 K
@@ -74,7 +76,9 @@ Its accumulation loop is a dot product:
 
 ```python
 sum_val = 0.0
-for charge_number, D1j, mj, nj in zip(charge_numbers, D1, masses, number_densities):
+for charge_number, D1j, mj, nj in zip(
+    charge_numbers, D1, masses, number_densities
+):
     sum_val += nj * mj * charge_number * D1j
 ```
 
@@ -157,7 +161,9 @@ constant, recomputed 1600 times per `q()` between them, and both recompute
 `functions_transport.py:1265` and `1380`:
 
 ```python
-a = np.dot(c_nn[l - 1, s - 1], beta_array, out=np.zeros((7,), dtype=np.float64))
+a = np.dot(
+    c_nn[l - 1, s - 1], beta_array, out=np.zeros((7,), dtype=np.float64)
+)
 ```
 
 The `out=` argument is handed a freshly allocated array, so it saves nothing
@@ -213,7 +219,9 @@ Laricchiuta is applied as a *recursive central finite difference in T*:
 
 ```python
 negT, posT = T - 0.5, T + 0.5
-return Qin(..., s - 1, T) + T / (s + 1) * (Qin(..., s - 1, posT) - Qin(..., s - 1, negT))
+return Qin(..., s - 1, T) + T / (s + 1) * (
+    Qin(..., s - 1, posT) - Qin(..., s - 1, negT)
+)
 ```
 
 Each level triples the call count. Measured over one `q()` call:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ path = "src/minplascalc/__init__.py"
 indent-width = 4
 line-length = 79
 
+[tool.ruff.format]
+docstring-code-format = true
+
 [tool.ruff.lint]
 exclude = [".venv"]
 ignore = [


### PR DESCRIPTION
Main goal was fixing the wasm bug in pre-commit which was hopefully solved by the gitleaks upgrade, but I ended up also swapping out blackdoc for a ruff-based version that does similar things. Note this will no longer format code blocks in .rst files, but we have none today.