### PR TITLE
Fix warnings in GitHub Actions

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -22,11 +22,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install the latest version of uv.
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         version: "latest"
+        enable-cache: false
     - uses: pre-commit/action@v3.0.1
 
   tests:
@@ -35,12 +36,13 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"] # Add more versions as needed.
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install the latest version of uv and set the python version.
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: extractions/setup-just@v2
+        enable-cache: false
+    - uses: extractions/setup-just@v3
     - name: Test with python ${{ matrix.python-version }}
       run: just tests
 
@@ -48,12 +50,13 @@ jobs:
     needs: [tests]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install the latest version of uv.
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         version: "latest"
-    - uses: extractions/setup-just@v2
+        enable-cache: false
+    - uses: extractions/setup-just@v3
     - name: Run code quality checks.
       run: just type-check
 
@@ -61,12 +64,13 @@ jobs:
     needs: [tests]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install the latest version of uv.
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         version: "latest"
-    - uses: extractions/setup-just@v2
+        enable-cache: false
+    - uses: extractions/setup-just@v3
     - name: Build the documentation.
       run: just build-docs
     - uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,11 @@ jobs:
       id-token: write
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: false
     - name: Build package
       run: uv build
     - name: Publish package distributions to PyPI

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,8 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: false
     - name: Run pytest
       run: uv run pytest tests --verbose --durations=5

--- a/.github/workflows/tests-cov.yml
+++ b/.github/workflows/tests-cov.yml
@@ -21,12 +21,13 @@ jobs:
     permissions:
       contents: write  # To save the coverage report.
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install the latest version of uv.
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         version: "latest"
-    - uses: extractions/setup-just@v2
+        enable-cache: false
+    - uses: extractions/setup-just@v3
     - name: Run tests with coverage.
       run: just tests-cov
     # See https://stackoverflow.com/a/75033525


### PR DESCRIPTION
Closes #97

- Update checkout, setup-uv, and setup-just to Node 24-compatible versions
- Disable setup-uv dependency caching because this project has no matching lockfile or requirements file

Validation:
- `just tests` (94 passed)
- `just type-check`
- pre-commit hooks