### PR TITLE
Correct Devoto A11 and A16 transport coefficients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added numba as dependency and used it to optimise q and qhat calculation functions.
+- Added a development-only symbolic derivation and randomized cross-check of
+  Devoto's A3--A22 collision-bracket matrices.
+- Added regressions for the reported Si-C-O thermal-conductivity outliers.
 
 ### Changed
 
 ### Fixed
 
+- Corrected the misplaced parentheses in the Devoto A11 and A16
+  $\\overline Q^{(2,2)}$ coefficients. Conductivity reference values change as
+  a result.
 - Renamed energylevels -> energy_levels
 - Moved package to src layout
 

--- a/bench/DEVOTO_SYMBOLIC_BRACKETS.md
+++ b/bench/DEVOTO_SYMBOLIC_BRACKETS.md
@@ -1,0 +1,73 @@
+# Symbolic Devoto collision-bracket audit
+
+`devoto_brackets_symbolic.py` independently derives the explicit collision
+brackets used by the Devoto transport matrices. It is a development tool, not
+a production dependency.
+
+The derivation begins with elastic two-body collision kinematics and the
+Sonine/Laguerre trial functions. It evaluates the centre-of-mass Maxwellian
+integrals as exact Gaussian moments, reduces the scattering-angle polynomial
+to transport cross sections, and applies the normalization of equation 11 in
+Devoto (1966). Coefficients remain exact SymPy rationals throughout.
+
+The vector basis reproduces every upper block in equations A3-A18. For A3 it
+first derives the raw `(0, 0)` collision bracket `R`. The mass-flux subsidiary
+condition has weights `w_i = n_i sqrt(m_i)`, so adding an outer product with
+`w` does not alter the bracket on an admissible coefficient vector. Devoto's
+zero-diagonal form follows directly as
+
+```text
+q00 = R - outer(diag(R) / w, w).
+```
+
+The symbolic order-zero pair moments are particularly small:
+
+```text
+self =  2 B^2 Q^(1,1)
+cross = -2 A B Q^(1,1),
+A^2 = m_i / (m_i + m_l),  B^2 = m_l / (m_i + m_l).
+```
+
+After the Maxwellian prefactor is applied, they give
+
+```text
+R_ii =  8 n_i sum_(l != i) n_l sqrt(m_l / (m_i + m_l)) Q_il^(1,1)
+R_ij = -8 n_i n_j sqrt(m_i / (m_i + m_j)) Q_ij^(1,1),  i != j.
+```
+
+Substitution into the constraint transformation gives
+`q00_ij = R_ij - R_ii n_j sqrt(m_j) / (n_i sqrt(m_i))`, whose expanded form
+is A3. The diagonal cancels identically. This derivation is useful because it
+checks both the collision algebra and the otherwise easy-to-miss constraint
+transformation.
+
+The traceless-tensor basis reproduces all viscosity blocks in A19-A22.
+
+## Checks
+
+The representative automated test derives all viscosity blocks and vector
+blocks A3, A4, A7, A12, A11, and A16:
+
+```console
+PYTHONPATH=. .venv/bin/pytest -q tests/test_devoto_symbolic_brackets.py
+```
+
+The complete fourth-order check, including the expensive `(3, 3)` block A18,
+is available explicitly:
+
+```console
+PYTHONPATH=. .venv/bin/python bench/devoto_brackets_symbolic.py --check
+```
+
+On a typical development machine the representative test takes roughly 25
+seconds and the complete derivation roughly one minute. SymPy is intentionally
+restricted to real variables, with the two positive mass coefficients marked
+positive as well. The implementation avoids unrestricted `simplify()` calls;
+it operates on polynomial domains and applies targeted factoring only after
+the Gaussian and angular moments have been collected.
+
+Run the module without `--check` to print every exact pair-bracket expansion:
+
+```console
+PYTHONPATH=. .venv/bin/python bench/devoto_brackets_symbolic.py
+```

--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -1,0 +1,1 @@
+"""Development benchmarks and independent numerical oracles."""

--- a/bench/devoto_brackets_symbolic.py
+++ b/bench/devoto_brackets_symbolic.py
@@ -1,0 +1,501 @@
+r"""Derive Devoto's collision-bracket matrices with exact symbolic algebra.
+
+This module is a development-time oracle for the explicit expressions in the
+appendix of Devoto (1966).  It starts before equations A3--A22: from the
+Sonine-polynomial trial functions, elastic two-body collision kinematics, and
+Maxwellian averages.  SymPy then performs the centre-of-mass Gaussian moments
+and collects the remaining relative-speed and scattering-angle polynomial in
+Devoto's averaged transport cross sections.
+
+The production implementation deliberately does not import this module.  Its
+purpose is to independently check the fast, handwritten Numba kernels in
+``minplascalc.functions_transport``.
+
+For species masses ``m_i`` and ``m_l``, introduce dimensionless centre-of-mass
+and relative velocities ``Y`` and ``gamma``.  With
+
+``A**2 = m_i / (m_i + m_l)`` and ``B**2 = m_l / (m_i + m_l)``, the
+pre-collision peculiar velocities are
+
+``W_i = A Y + B gamma n`` and ``W_l = B Y - A gamma n``.
+
+An elastic collision rotates ``n`` to ``n_prime``.  The vector trial functions
+for diffusion and heat conduction are
+
+``W L_m**(3/2)(W**2)``,
+
+and the traceless-tensor trial functions for viscosity are
+
+``(W W - W**2 I / 3) L_m**(5/2)(W**2)``.
+
+No coefficients from Devoto's appendix appear below.  The only convention
+specific to that paper is the normalization relating a raw radial/angular
+moment to its barred ``Q^(l,s)`` in equation 11.
+"""
+
+from __future__ import annotations
+
+import argparse
+from functools import lru_cache
+from math import sqrt
+from types import SimpleNamespace
+from typing import Literal
+
+import numpy as np
+import sympy as sp
+
+Rank = Literal[1, 2]
+Channel = Literal["self", "cross"]
+
+_YX, _YY, _YZ = sp.symbols("Y_x Y_y Y_z", real=True)
+_GAMMA, _COS_CHI, _SIN_CHI = sp.symbols("gamma cos_chi sin_chi", real=True)
+_A, _B = sp.symbols("A B", positive=True, real=True)
+
+_Y = sp.Matrix([_YX, _YY, _YZ])
+_N = sp.Matrix([0, 0, 1])
+_N_PRIME = sp.Matrix([_SIN_CHI, 0, _COS_CHI])
+_IDENTITY = sp.eye(3)
+
+
+def _gaussian_moment(power: int) -> sp.Rational:
+    r"""Return ``E[X**power]`` for density ``exp(-X**2) / sqrt(pi)``."""
+    if power % 2:
+        return sp.S.Zero
+    if power == 0:
+        return sp.S.One
+    return sp.factorial2(power - 1) / sp.Integer(2) ** (power // 2)
+
+
+def _maxwellian_com_average(expression: sp.Expr) -> sp.Expr:
+    """Integrate a polynomial over the dimensionless COM Maxwellian."""
+    polynomial = sp.Poly(sp.expand(expression), _YX, _YY, _YZ)
+    result = sp.S.Zero
+    for powers, coefficient in polynomial.terms():
+        result += coefficient * sp.prod(
+            _gaussian_moment(power) for power in powers
+        )
+
+    # Rotational invariance makes the result even in sin(chi).  Replacing its
+    # even powers by (1 - cos(chi)**2) completes the azimuth-independent
+    # scattering-angle reduction.
+    sin_polynomial = sp.Poly(sp.expand(result), _SIN_CHI)
+    reduced = sp.S.Zero
+    for (power,), coefficient in sin_polynomial.terms():
+        if power % 2:
+            raise ValueError("Unexpected odd scattering-azimuth contribution")
+        reduced += coefficient * (1 - _COS_CHI**2) ** (power // 2)
+    return sp.factor(sp.expand(reduced))
+
+
+def _trial_function(velocity: sp.Matrix, rank: Rank, order: int):
+    """Return a vector or traceless-tensor Sonine trial function."""
+    speed_squared = sp.expand(velocity.dot(velocity))
+    if rank == 1:
+        basis = velocity
+        alpha = sp.Rational(3, 2)
+    elif rank == 2:
+        basis = velocity * velocity.T - speed_squared * _IDENTITY / sp.Integer(
+            3
+        )
+        alpha = sp.Rational(5, 2)
+    else:  # pragma: no cover - protected by the public type and tests
+        raise ValueError(f"Unsupported tensor rank: {rank}")
+    return basis * sp.assoc_laguerre(order, alpha, speed_squared)
+
+
+def _collision_change(
+    com_coefficient: sp.Expr,
+    relative_coefficient: sp.Expr,
+    rank: Rank,
+    order: int,
+):
+    """Return post-collision minus pre-collision trial functions."""
+    before = com_coefficient * _Y + relative_coefficient * _GAMMA * _N
+    after = com_coefficient * _Y + relative_coefficient * _GAMMA * _N_PRIME
+    return _trial_function(after, rank, order) - _trial_function(
+        before, rank, order
+    )
+
+
+def _inner_product(left, right, rank: Rank) -> sp.Expr:
+    """Contract vector or tensor collision changes."""
+    if rank == 1:
+        return left.dot(right)
+    return sum(
+        left[row, column] * right[row, column]
+        for row in range(3)
+        for column in range(3)
+    )
+
+
+def _q_normalization(l_value: int, s_value: int) -> sp.Rational:
+    r"""Prefactor mapping a raw moment to Devoto's barred Q, equation 11."""
+    return sp.Rational(
+        4 * (l_value + 1),
+        sp.factorial(s_value + 1) * (2 * l_value + 1 - (-1) ** l_value),
+    )
+
+
+def _collect_transport_moments(
+    averaged_bracket: sp.Expr,
+) -> dict[tuple[int, int], sp.Expr]:
+    r"""Collect a bracket as coefficients of barred ``Q^(l,s)`` moments."""
+    radial_polynomial = sp.Poly(sp.expand(averaged_bracket), _GAMMA)
+    by_radial_power: dict[int, sp.Expr] = {}
+    for (power,), coefficient in radial_polynomial.terms():
+        if power % 2:
+            raise ValueError("Unexpected odd relative-speed contribution")
+        by_radial_power[power // 2] = coefficient
+
+    result: dict[tuple[int, int], sp.Expr] = {}
+    for s_value, angular_expression in by_radial_power.items():
+        angular_polynomial = sp.Poly(sp.expand(angular_expression), _COS_CHI)
+        raw_coefficients: dict[int, sp.Expr] = {}
+        for l_value in range(1, angular_polynomial.degree() + 1):
+            coefficient = angular_polynomial.coeff_monomial(_COS_CHI**l_value)
+            if coefficient != 0:
+                # P(cos chi) = sum_l a_l (1 - cos(chi)**l).
+                raw_coefficients[l_value] = -coefficient
+
+        if (
+            sp.simplify(
+                angular_polynomial.coeff_monomial(1)
+                - sum(raw_coefficients.values(), sp.S.Zero)
+            )
+            != 0
+        ):
+            raise ValueError("Collision bracket does not vanish at chi = 0")
+
+        for l_value, raw_coefficient in raw_coefficients.items():
+            result[l_value, s_value] = sp.factor(
+                raw_coefficient / _q_normalization(l_value, s_value)
+            )
+    return result
+
+
+@lru_cache(maxsize=None)
+def derive_pair_moments(
+    rank: Rank,
+    left_order: int,
+    right_order: int,
+    channel: Channel,
+) -> dict[tuple[int, int], sp.Expr]:
+    """Derive exact collision-moment coefficients for one ordered pair.
+
+    ``self`` contracts the change of the two basis functions belonging to
+    species ``i``.  ``cross`` contracts the species-``i`` change with the
+    species-``l`` change.  Together these are the diagonal and off-diagonal
+    binary-collision contributions to Devoto's bracket matrix.
+    """
+    left_change = _collision_change(_A, _B, rank, left_order)
+    if channel == "self":
+        right_change = _collision_change(_A, _B, rank, right_order)
+    elif channel == "cross":
+        right_change = _collision_change(_B, -_A, rank, right_order)
+    else:  # pragma: no cover - protected by the public type and tests
+        raise ValueError(f"Unsupported collision channel: {channel}")
+
+    contracted = _inner_product(left_change, right_change, rank)
+    averaged = _maxwellian_com_average(contracted)
+    return _collect_transport_moments(averaged)
+
+
+@lru_cache(maxsize=None)
+def _moment_evaluator(
+    rank: Rank,
+    left_order: int,
+    right_order: int,
+    channel: Channel,
+):
+    moments = derive_pair_moments(rank, left_order, right_order, channel)
+    keys = tuple(sorted(moments))
+    function = sp.lambdify((_A, _B), [moments[key] for key in keys], "numpy")
+    return keys, function
+
+
+def _evaluate_pair_bracket(
+    rank: Rank,
+    left_order: int,
+    right_order: int,
+    channel: Channel,
+    mass_fraction_i: float,
+    mass_fraction_l: float,
+    collision_integrals: dict[tuple[int, int], float],
+) -> float:
+    keys, function = _moment_evaluator(rank, left_order, right_order, channel)
+    coefficients = np.atleast_1d(
+        function(sqrt(mass_fraction_i), sqrt(mass_fraction_l))
+    ).astype(float)
+    return float(
+        sum(
+            coefficient * collision_integrals[key]
+            for key, coefficient in zip(keys, coefficients)
+        )
+    )
+
+
+def assemble_upper_bracket_matrix(
+    masses: np.ndarray,
+    number_densities: np.ndarray,
+    collision_integrals: dict[tuple[int, int], np.ndarray],
+    *,
+    rank: Rank,
+    maximum_order: int,
+) -> np.ndarray:
+    """Assemble upper Sonine blocks from the symbolic collision brackets.
+
+    For the vector ``(0, 0)`` block, :func:`assemble_bracket_block` also
+    applies the diffusion subsidiary constraint that turns the raw bracket
+    into Devoto's equation A3.  The remaining blocks are raw bracket results.
+    """
+    masses = np.asarray(masses, dtype=float)
+    number_densities = np.asarray(number_densities, dtype=float)
+    species_count = len(masses)
+    result = np.full(
+        (
+            (maximum_order + 1) * species_count,
+            (maximum_order + 1) * species_count,
+        ),
+        np.nan,
+    )
+
+    for left_order in range(maximum_order + 1):
+        for right_order in range(left_order, maximum_order + 1):
+            block = assemble_bracket_block(
+                masses,
+                number_densities,
+                collision_integrals,
+                rank=rank,
+                left_order=left_order,
+                right_order=right_order,
+            )
+
+            row = slice(
+                left_order * species_count,
+                (left_order + 1) * species_count,
+            )
+            column = slice(
+                right_order * species_count,
+                (right_order + 1) * species_count,
+            )
+            result[row, column] = block
+    return result
+
+
+def assemble_bracket_block(
+    masses: np.ndarray,
+    number_densities: np.ndarray,
+    collision_integrals: dict[tuple[int, int], np.ndarray],
+    *,
+    rank: Rank,
+    left_order: int,
+    right_order: int,
+) -> np.ndarray:
+    """Assemble one exact-symbolic Devoto bracket block numerically.
+
+    The vector ``(0, 0)`` coefficients obey the mass-flux subsidiary
+    condition ``sum_i n_i sqrt(m_i) c_i0 = 0``.  If ``R`` is the raw bracket
+    and ``w_i = n_i sqrt(m_i)``, adding any outer product ``a w.T`` therefore
+    leaves its action on an admissible coefficient vector unchanged.  Devoto
+    chooses ``a_i = -R_ii / w_i``, giving equation A3:
+
+    ``q00 = R - outer(diag(R) / w, w)``.
+    """
+    masses = np.asarray(masses, dtype=float)
+    number_densities = np.asarray(number_densities, dtype=float)
+    species_count = len(masses)
+    block = np.zeros((species_count, species_count))
+    for i in range(species_count):
+        for l_index in range(species_count):
+            total_mass = masses[i] + masses[l_index]
+            x_value = masses[i] / total_mass
+            y_value = masses[l_index] / total_mass
+            pair_q = {
+                key: values[i, l_index]
+                for key, values in collision_integrals.items()
+            }
+            prefactor = (
+                4
+                * number_densities[i]
+                * number_densities[l_index]
+                / sqrt(y_value)
+            )
+            self_bracket = _evaluate_pair_bracket(
+                rank,
+                left_order,
+                right_order,
+                "self",
+                x_value,
+                y_value,
+                pair_q,
+            )
+            if i == l_index:
+                cross_bracket = _evaluate_pair_bracket(
+                    rank,
+                    left_order,
+                    right_order,
+                    "cross",
+                    x_value,
+                    y_value,
+                    pair_q,
+                )
+                block[i, i] += prefactor * (self_bracket + cross_bracket)
+            else:
+                block[i, i] += prefactor * self_bracket
+                block[i, l_index] += prefactor * _evaluate_pair_bracket(
+                    rank,
+                    left_order,
+                    right_order,
+                    "cross",
+                    x_value,
+                    y_value,
+                    pair_q,
+                )
+    if rank == 1 and left_order == right_order == 0:
+        constraint_weights = number_densities * np.sqrt(masses)
+        block -= np.outer(
+            np.diag(block) / constraint_weights,
+            constraint_weights,
+        )
+        # The subtraction above is exact algebraically.  Preserve Devoto's
+        # exact zero-diagonal convention rather than retaining roundoff from
+        # subtracting two equal floating-point values.
+        np.fill_diagonal(block, 0.0)
+    return block
+
+
+def format_pair_moments(
+    rank: Rank, left_order: int, right_order: int, channel: Channel
+) -> str:
+    """Return a stable, human-readable exact derivation result."""
+    moments = derive_pair_moments(rank, left_order, right_order, channel)
+    return " + ".join(
+        f"({sp.sstr(coefficient)}) Q^({l_value},{s_value})"
+        for (l_value, s_value), coefficient in sorted(moments.items())
+    )
+
+
+def check_production_kernels() -> dict[str, float]:
+    """Derive every supported block and compare with production kernels."""
+    from minplascalc import functions_transport as ft
+
+    rng = np.random.default_rng(1966)
+    species_count = 3
+    masses = np.array([1.7, 2.9, 5.3])
+    number_densities = np.array([2.3, 3.1, 4.7])
+    collision_integrals = {}
+    for moment in ft.LS_PAIRS:
+        values = rng.uniform(0.5, 2.0, (species_count, species_count))
+        collision_integrals[moment] = (values + values.T) / 2
+
+    state = SimpleNamespace(
+        masses=masses,
+        number_densities=number_densities,
+    )
+
+    class ArtificialMixture:
+        species = tuple(range(species_count))
+
+        def __init__(self):
+            self.masses = masses
+
+        @staticmethod
+        def calculate_composition():
+            return number_densities
+
+        @staticmethod
+        def _equilibrium_state():
+            return state
+
+    mixture = ArtificialMixture()
+    comparisons = (
+        (
+            "q",
+            ft.q(mixture, collision_integrals),
+            assemble_upper_bracket_matrix(
+                masses,
+                number_densities,
+                collision_integrals,
+                rank=1,
+                maximum_order=3,
+            ),
+            3,
+        ),
+        (
+            "qhat",
+            ft.qhat(mixture, collision_integrals),
+            assemble_upper_bracket_matrix(
+                masses,
+                number_densities,
+                collision_integrals,
+                rank=2,
+                maximum_order=1,
+            ),
+            1,
+        ),
+    )
+
+    errors = {}
+    for name, actual, derived, maximum_order in comparisons:
+        for left_order in range(maximum_order + 1):
+            for right_order in range(left_order, maximum_order + 1):
+                row = slice(
+                    left_order * species_count,
+                    (left_order + 1) * species_count,
+                )
+                column = slice(
+                    right_order * species_count,
+                    (right_order + 1) * species_count,
+                )
+                actual_block = actual[row, column]
+                derived_block = derived[row, column]
+                block_scale = max(
+                    float(np.max(np.abs(actual_block))),
+                    float(np.max(np.abs(derived_block))),
+                    float(np.finfo(float).tiny),
+                )
+                scaled_error = float(
+                    np.max(np.abs(actual_block - derived_block)) / block_scale
+                )
+                label = f"{name}[{left_order},{right_order}]"
+                errors[label] = scaled_error
+                if not np.allclose(
+                    actual_block,
+                    derived_block,
+                    rtol=2e-12,
+                    atol=1e-12,
+                ):
+                    raise AssertionError(
+                        f"{label} differs by block-scaled error {scaled_error}"
+                    )
+    return errors
+
+
+def _print_derivations() -> None:
+    for tensor_rank, highest_order in ((1, 3), (2, 1)):
+        print(f"rank {tensor_rank}")
+        for m_order in range(highest_order + 1):
+            for p_order in range(m_order, highest_order + 1):
+                print(
+                    f"  ({m_order}, {p_order}) self : "
+                    f"{format_pair_moments(tensor_rank, m_order, p_order, 'self')}"  # noqa: E501
+                )
+                print(
+                    f"  ({m_order}, {p_order}) cross: "
+                    f"{format_pair_moments(tensor_rank, m_order, p_order, 'cross')}"  # noqa: E501
+                )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare every derived block with the production kernels",
+    )
+    arguments = parser.parse_args()
+    if arguments.check:
+        for block, error in check_production_kernels().items():
+            print(f"{block}: block-scaled error {error:.3e}")
+    else:
+        _print_derivations()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dev = [
   # Development dependencies.
   "matplotlib",
   "jupyter",
+  "sympy",
   # Tests dependencies.
   "pytest",
   "pytest-cov",
@@ -68,6 +69,9 @@ allow-direct-references = true
 
 [tool.hatch.version]
 path = "src/minplascalc/__init__.py"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
 
 [tool.ruff]
 indent-width = 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,10 @@ allow-direct-references = true
 [tool.hatch.version]
 path = "src/minplascalc/__init__.py"
 
+[[tool.mypy.overrides]]
+follow_imports = "skip"
+module = "bench.*"
+
 [tool.pytest.ini_options]
 pythonpath = ["."]
 

--- a/src/minplascalc/functions_transport.py
+++ b/src/minplascalc/functions_transport.py
@@ -2388,7 +2388,7 @@ def _q22_jit(
                     7
                     * masses[j]
                     * masses[l]
-                    * (4 * (masses[j] ** 2 + 7 * masses[l] ** 2))
+                    * (4 * masses[j] ** 2 + 7 * masses[l] ** 2)
                     * Q22[i, l]
                     - 112 * masses[j] * masses[l] ** 3 * Q23[i, l]
                     + 80 * masses[j] * masses[l] ** 3 * Q24[i, l]
@@ -2468,7 +2468,7 @@ def _q23_jit(
                     / 4
                     * masses[j]
                     * masses[l]
-                    * (8 * (masses[j] ** 2 + 7 * masses[l] ** 2))
+                    * (8 * masses[j] ** 2 + 7 * masses[l] ** 2)
                     * Q22[i, l]
                     - 18
                     * masses[j]

--- a/tests/test_devoto_q_matrix.py
+++ b/tests/test_devoto_q_matrix.py
@@ -1,0 +1,210 @@
+"""Regression tests for the Devoto appendix q-matrix expressions."""
+
+import numpy as np
+import pytest
+
+import minplascalc as mpc
+from minplascalc import functions_transport as ft
+
+SICO_SPECIES = [
+    "Si",
+    "C",
+    "O",
+    "SiO",
+    "CO",
+    "O2",
+    "Si+",
+    "C+",
+    "O+",
+    "Si++",
+    "C++",
+    "O++",
+]
+
+
+def _expected_q22_q22_term(masses, number_densities, q22):
+    count = len(masses)
+    expected = np.zeros((count, count))
+    for i in range(count):
+        for j in range(count):
+            total = 0.0
+            for l in range(count):
+                total += (
+                    number_densities[l]
+                    * masses[l] ** 0.5
+                    / (masses[i] + masses[l]) ** 4.5
+                    * (ft.delta(i, j) + ft.delta(j, l))
+                    * 7
+                    * masses[j]
+                    * masses[l]
+                    * (4 * masses[j] ** 2 + 7 * masses[l] ** 2)
+                    * q22[i, l]
+                )
+            expected[i, j] = (
+                8
+                * number_densities[i]
+                * (masses[i] / masses[j]) ** 2.5
+                * total
+            )
+    return expected
+
+
+def _expected_q23_q22_term(masses, number_densities, q22):
+    count = len(masses)
+    expected = np.zeros((count, count))
+    for i in range(count):
+        for j in range(count):
+            total = 0.0
+            for l in range(count):
+                total += (
+                    number_densities[l]
+                    * masses[l] ** 1.5
+                    / (masses[i] + masses[l]) ** 5.5
+                    * (ft.delta(i, j) + ft.delta(j, l))
+                    * 63
+                    / 4
+                    * masses[j]
+                    * masses[l]
+                    * (8 * masses[j] ** 2 + 7 * masses[l] ** 2)
+                    * q22[i, l]
+                )
+            expected[i, j] = (
+                8
+                * number_densities[i]
+                * (masses[i] / masses[j]) ** 3.5
+                * total
+            )
+    return expected
+
+
+@pytest.fixture
+def q22_only_inputs():
+    masses = np.array([2.0, 3.0])
+    number_densities = np.array([5.0, 7.0])
+    q22 = np.array([[11.0, 13.0], [17.0, 19.0]])
+    zeros = np.zeros_like(q22)
+    return masses, number_densities, q22, zeros
+
+
+def test_q22_uses_devoto_a11_q22_coefficient(q22_only_inputs):
+    masses, number_densities, q22, zeros = q22_only_inputs
+    actual = ft._q22_jit(
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        q22,
+        zeros,
+        zeros,
+        zeros,
+        masses,
+        len(masses),
+        number_densities,
+    )
+    expected = _expected_q22_q22_term(masses, number_densities, q22)
+    assert actual == pytest.approx(expected)
+
+
+def test_q23_uses_devoto_a16_q22_coefficient(q22_only_inputs):
+    masses, number_densities, q22, zeros = q22_only_inputs
+    actual = ft._q23_jit(
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        q22,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        zeros,
+        masses,
+        len(masses),
+        number_densities,
+    )
+    expected = _expected_q23_q22_term(masses, number_densities, q22)
+    assert actual == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "x0, center_temperature",
+    [
+        (
+            [
+                0.19754580488363843,
+                0.30290296560926583,
+                0.4995512295070957,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            17800.0,
+        ),
+        (
+            [
+                0.1321622922145921,
+                0.37018534501125755,
+                0.4976523627741504,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            15100.0,
+        ),
+        (
+            [
+                0.4525320530234709,
+                0.45677295691031883,
+                0.09069499006621033,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            16300.0,
+        ),
+    ],
+    ids=["Tbath-2342K", "Tbath-2529K", "Tbath-3211K"],
+)
+def test_reported_thermal_conductivity_outliers_are_smooth(
+    x0, center_temperature
+):
+    mixture = mpc.mixture.lte_from_names(
+        SICO_SPECIES,
+        x0=x0,
+        T=center_temperature - 1,
+        P=101325.0,
+    )
+    conductivities = []
+    for temperature in (
+        center_temperature - 1,
+        center_temperature,
+        center_temperature + 1,
+    ):
+        mixture.T = temperature
+        conductivities.append(mixture.calculate_thermal_conductivity())
+
+    assert np.all(np.isfinite(conductivities))
+    assert np.all(np.asarray(conductivities) > 0)
+    midpoint = (conductivities[0] + conductivities[2]) / 2
+    assert conductivities[1] == pytest.approx(midpoint, abs=1e-4)

--- a/tests/test_devoto_symbolic_brackets.py
+++ b/tests/test_devoto_symbolic_brackets.py
@@ -1,0 +1,105 @@
+"""Cross-check Devoto kernels against symbolic collision brackets."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from bench.devoto_brackets_symbolic import assemble_bracket_block
+from minplascalc import functions_transport as ft
+
+
+@pytest.fixture(scope="module")
+def artificial_transport_system():
+    rng = np.random.default_rng(1966)
+    species_count = 3
+    masses = np.array([1.7, 2.9, 5.3])
+    number_densities = np.array([2.3, 3.1, 4.7])
+    collision_integrals = {}
+    for moment in ft.LS_PAIRS:
+        values = rng.uniform(0.5, 2.0, (species_count, species_count))
+        collision_integrals[moment] = (values + values.T) / 2
+
+    state = SimpleNamespace(
+        masses=masses,
+        number_densities=number_densities,
+    )
+
+    class ArtificialMixture:
+        species = tuple(range(species_count))
+
+        def __init__(self):
+            self.masses = masses
+
+        @staticmethod
+        def calculate_composition():
+            return number_densities
+
+        @staticmethod
+        def _equilibrium_state():
+            return state
+
+    mixture = ArtificialMixture()
+    return masses, number_densities, collision_integrals, mixture
+
+
+@pytest.mark.parametrize(
+    "left_order, right_order",
+    [(0, 0), (0, 1), (1, 1)],
+)
+def test_symbolic_viscosity_brackets_match_devoto_kernels(
+    artificial_transport_system, left_order, right_order
+):
+    masses, number_densities, collision_integrals, mixture = (
+        artificial_transport_system
+    )
+    actual_matrix = ft.qhat(mixture, collision_integrals)
+    species_count = len(masses)
+    actual = actual_matrix[
+        left_order * species_count : (left_order + 1) * species_count,
+        right_order * species_count : (right_order + 1) * species_count,
+    ]
+    derived = assemble_bracket_block(
+        masses,
+        number_densities,
+        collision_integrals,
+        rank=2,
+        left_order=left_order,
+        right_order=right_order,
+    )
+    assert actual == pytest.approx(derived, rel=2e-13)
+
+
+@pytest.mark.parametrize(
+    "left_order, right_order",
+    [
+        (0, 0),
+        (0, 1),
+        (0, 2),
+        (0, 3),
+        (2, 2),
+        (2, 3),
+    ],
+    ids=["A3", "A4", "A7", "A12", "A11", "A16"],
+)
+def test_symbolic_diffusion_brackets_match_devoto_kernels(
+    artificial_transport_system, left_order, right_order
+):
+    masses, number_densities, collision_integrals, mixture = (
+        artificial_transport_system
+    )
+    actual_matrix = ft.q(mixture, collision_integrals)
+    species_count = len(masses)
+    actual = actual_matrix[
+        left_order * species_count : (left_order + 1) * species_count,
+        right_order * species_count : (right_order + 1) * species_count,
+    ]
+    derived = assemble_bracket_block(
+        masses,
+        number_densities,
+        collision_integrals,
+        rank=1,
+        left_order=left_order,
+        right_order=right_order,
+    )
+    assert actual == pytest.approx(derived, rel=2e-13)

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -156,11 +156,11 @@ def test_viscosity_complex(mixture_complex, x0, result, tol):
 @pytest.mark.parametrize(
     "T, P, result, tol",
     [
-        (MID_T, MID_P, 1.6850647038100455, 1e-5),
-        (LOW_T, LOW_P, 0.051617047811510164, 1e-7),
-        (HIGH_T, LOW_P, 4.464206850824014, 1e-5),
-        (LOW_T, HIGH_P, 0.05161701653293017, 1e-7),
-        (HIGH_T, HIGH_P, 6.620655660595108, 1e-5),
+        (MID_T, MID_P, 1.6059411995888206, 1e-5),
+        (LOW_T, LOW_P, 0.052125335672304166, 1e-7),
+        (HIGH_T, LOW_P, 5.469144033857229, 1e-5),
+        (LOW_T, HIGH_P, 0.0521253043533545, 1e-7),
+        (HIGH_T, HIGH_P, 8.04668554450143, 1e-5),
     ],
 )
 def test_thermal_conductivity_simple(mixture_simple, T, P, result, tol):
@@ -175,9 +175,9 @@ def test_thermal_conductivity_simple(mixture_simple, T, P, result, tol):
 @pytest.mark.parametrize(
     "x0, result, tol",
     [
-        (LOW_X0, 1.9640250363781075, 1e-5),
-        (MID_X0, 2.1890014838932124, 1e-5),
-        (HIGH_X0, 2.3835646495764453, 1e-5),
+        (LOW_X0, 2.054123612714577, 1e-5),
+        (MID_X0, 2.275659141366203, 1e-5),
+        (HIGH_X0, 2.4269824515817566, 1e-5),
     ],
 )
 def test_thermal_conductivity_complex(mixture_complex, x0, result, tol):
@@ -191,9 +191,9 @@ def test_thermal_conductivity_complex(mixture_complex, x0, result, tol):
 @pytest.mark.parametrize(
     "T, P, result, tol",
     [
-        (MID_T, MID_P, 2464.34348786605, 1e-2),
-        (HIGH_T, LOW_P, 9130.048623089211, 1e-2),
-        (HIGH_T, HIGH_P, 18151.817978997307, 1e-2),
+        (MID_T, MID_P, 2523.9995883041697, 1e-2),
+        (HIGH_T, LOW_P, 9197.57578660961, 1e-2),
+        (HIGH_T, HIGH_P, 18227.372128141295, 1e-2),
     ],
 )
 def test_electrical_conductivity_simple(mixture_simple, T, P, result, tol):
@@ -208,9 +208,9 @@ def test_electrical_conductivity_simple(mixture_simple, T, P, result, tol):
 @pytest.mark.parametrize(
     "x0, result, tol",
     [
-        (LOW_X0, 4727.109691310277, 1e-2),
-        (MID_X0, 4468.541344858815, 1e-2),
-        (HIGH_X0, 3925.856615193799, 1e-2),
+        (LOW_X0, 4749.608571071909, 1e-2),
+        (MID_X0, 4494.919012112646, 1e-2),
+        (HIGH_X0, 3959.917326780716, 1e-2),
     ],
 )
 def test_electrical_conductivity_complex(mixture_complex, x0, result, tol):

--- a/tests/test_mixture_without_electrons.py
+++ b/tests/test_mixture_without_electrons.py
@@ -156,11 +156,11 @@ def test_viscosity_complex(mixture_complex, x0, result, tol):
 @pytest.mark.parametrize(
     "T, P, result, tol",
     [
-        (MID_T, MID_P, 6.7866322606356388e-01, 1e-5),
-        (LOW_T, LOW_P, 5.8235971093909315e-02, 1e-7),
-        (HIGH_T, LOW_P, 2.4297978641986884e-01, 1e-5),
-        (LOW_T, HIGH_P, 5.8235947511628458e-02, 1e-7),
-        (HIGH_T, HIGH_P, 4.8534654335503202e-01, 1e-5),
+        (MID_T, MID_P, 6.800857920705657e-01, 1e-5),
+        (LOW_T, LOW_P, 5.903704964428261e-02, 1e-7),
+        (HIGH_T, LOW_P, 2.4280416800390991e-01, 1e-5),
+        (LOW_T, HIGH_P, 5.9037026025524894e-02, 1e-7),
+        (HIGH_T, HIGH_P, 4.855691838684442e-01, 1e-5),
     ],
 )
 def test_thermal_conductivity_simple(mixture_simple, T, P, result, tol):
@@ -175,9 +175,9 @@ def test_thermal_conductivity_simple(mixture_simple, T, P, result, tol):
 @pytest.mark.parametrize(
     "x0, result, tol",
     [
-        (LOW_X0, 1.3852322593775698e-01, 1e-5),
-        (MID_X0, 1.1670757515955714e-01, 1e-5),
-        (HIGH_X0, 9.1312645060542125e-02, 1e-5),
+        (LOW_X0, 1.4006276613762003e-01, 1e-5),
+        (MID_X0, 1.1822894617782748e-01, 1e-5),
+        (HIGH_X0, 9.237671740729556e-02, 1e-5),
     ],
 )
 def test_thermal_conductivity_complex(mixture_complex, x0, result, tol):


### PR DESCRIPTION
## Summary

- correct the misplaced parentheses in the Devoto A11 and A16 Q(2,2) coefficients
- add an independent SymPy derivation and randomized cross-check for the A3-A22 collision-bracket matrices
- add regression coverage for Quinn’s three reported Si-C-O thermal-conductivity outliers
- update conductivity reference values affected by the transcription corrections

This is the first PR in the planned productionization stack, deliberately separated from the computation-state and analytical-derivative refactors.

## Validation

- uv run pytest tests docs -q with Markdown and RST doctest globs: 108 passed
- uv run python bench/devoto_brackets_symbolic.py --check: maximum block-scaled error 6.38e-16
- uv run mypy src
- uv run pre-commit run on all changed files
- uv lock --check
- just build-docs (succeeds with existing documentation warnings)