### PR TITLE
Consolidate equilibrium and transport computation state

### DIFF
--- a/src/minplascalc/functions_radiation.py
+++ b/src/minplascalc/functions_radiation.py
@@ -104,7 +104,8 @@ def total_emission_coefficient(mix: "LTE") -> float:
     coefficient (NEC).
     """
     # Calculate the number densities of species in the mixture.
-    nd = mix.calculate_composition()
+    state = mix._equilibrium_state()
+    nd = state.number_densities
 
     # Initialize the total emission coefficient.
     total_emission_coefficient = 0.0

--- a/src/minplascalc/functions_transport.py
+++ b/src/minplascalc/functions_transport.py
@@ -2752,6 +2752,48 @@ def _qhat11_jit(
 ### Transport property calculations ###########################################
 
 
+class _TransportWorkspace:
+    """Lazily evaluated transport intermediates for one mixture state."""
+
+    def __init__(self, mixture: "LTE"):
+        self.mixture = mixture
+        self.state = mixture._equilibrium_state()
+        self._Q: dict[tuple[int, int], np.ndarray] = {}
+        self._q: np.ndarray | None = None
+        self._qhat: np.ndarray | None = None
+        self._q_system: "_QSystem | None" = None
+
+    def collision_integrals(
+        self, moments: tuple[tuple[int, int], ...]
+    ) -> dict[tuple[int, int], np.ndarray]:
+        """Return requested moments, calculating only entries not yet held."""
+        missing = tuple(moment for moment in moments if moment not in self._Q)
+        if missing:
+            self._Q.update(collision_integrals(self.mixture, missing))
+        return self._Q
+
+    @property
+    def q(self) -> np.ndarray:
+        if self._q is None:
+            self._q = q(self.mixture, self.collision_integrals(LS_PAIRS))
+        return self._q
+
+    @property
+    def qhat(self) -> np.ndarray:
+        if self._qhat is None:
+            self._qhat = qhat(
+                self.mixture,
+                self.collision_integrals(QHAT_LS_PAIRS),
+            )
+        return self._qhat
+
+    @property
+    def q_system(self) -> "_QSystem":
+        if self._q_system is None:
+            self._q_system = _QSystem(self.mixture, self.q)
+        return self._q_system
+
+
 class _QSystem:
     """Factorized Devoto q-system and its shared solution families."""
 
@@ -3003,11 +3045,12 @@ def viscosity(mixture: "LTE") -> float:
     TODO: Why not use equation 21?
     """
     nb_species = len(mixture.species)
-    state = mixture._equilibrium_state()
+    workspace = mixture._transport_workspace()
+    state = workspace.state
     number_densities = state.number_densities
     masses = state.masses
 
-    qqhat = qhat(mixture)
+    qqhat = workspace.qhat
 
     b_vec = np.zeros(2 * nb_species)  # 2 for 2nd order approximation
     b_vec[:nb_species] = (
@@ -3064,13 +3107,14 @@ def electrical_conductivity(mixture: "LTE") -> float:
     """
     # This function should only be called for electron-containing mixtures
     # Non-electron mixtures should return 0 via their template method override
-    state = mixture._equilibrium_state()
+    workspace = mixture._transport_workspace()
+    state = workspace.state
     charge_numbers = state.charge_numbers
     number_densities = state.number_densities
     masses = state.masses
     rho = state.rho
 
-    D1 = Dij(mixture)[-1, :]
+    D1 = workspace.q_system.diffusion_matrix()[-1, :]
     n_tot = state.n_tot
 
     # TODO: Check if this is correct. Electrons should be discarded.
@@ -3200,7 +3244,8 @@ def thermal_conductivity(
               a_{j 1}
     """
     nb_species = len(mixture.species)
-    state = mixture._equilibrium_state()
+    workspace = mixture._transport_workspace()
+    state = workspace.state
     number_densities = state.number_densities
     masses = state.masses
     n_tot = state.n_tot
@@ -3216,9 +3261,7 @@ def thermal_conductivity(
     # This q-matrix is reused by DTi and Dij below: the temperature and
     # composition are the same for all three (the +/- dT excursions further
     # down restore T before Dij is called).
-    qq = q(mixture)
-
-    q_system = _QSystem(mixture, qq)
+    q_system = workspace.q_system
     aip = q_system.aip
     # Equation 13 of [Devoto1966]_.
     k_dash = (

--- a/src/minplascalc/functions_transport.py
+++ b/src/minplascalc/functions_transport.py
@@ -1178,9 +1178,10 @@ def Qe(species_i: "Species", l: int, s: int, T: float) -> float:
 #: Largest energy-moment order with its own fit coefficients, per l.
 #: Above this, eq. 18 of [Laricchiuta2007]_ generates the value from a
 #: temperature derivative of the tabulated one.
-_BASE_S = {1: 5, 2: 4, 3: 3, 4: 4}
+_BASE_S = (0, 5, 4, 3, 4)
 
 
+@njit
 def _omega_star(x: float, a: np.ndarray, k: int, s0: int) -> float:
     r"""Reduced collision integral at moment order ``s0 + k``.
 
@@ -1259,6 +1260,7 @@ def _omega_star(x: float, a: np.ndarray, k: int, s0: int) -> float:
     return np.exp(g) * P
 
 
+@njit
 def _omega_fit(
     table: np.ndarray,
     sigma: float,

--- a/src/minplascalc/functions_transport.py
+++ b/src/minplascalc/functions_transport.py
@@ -1720,6 +1720,14 @@ _QC_C2 = (1 / 2, 1.0, 7 / 6, 4 / 3)
 _PSICONST = {s: psiconst(s) for s in _S_VALUES}
 _SUM1 = {s: sum1(s) for s in _S_VALUES}
 _SUM2 = {s: sum2(s) for s in _S_VALUES}
+_PSICONST_ARRAY = np.array([0.0] + [_PSICONST[s] for s in _S_VALUES])
+_SUM1_ARRAY = np.array([0.0] + [_SUM1[s] for s in _S_VALUES])
+_SUM2_ARRAY = np.array([0.0] + [_SUM2[s] for s in _S_VALUES])
+
+_PAIR_CHARGED = 0
+_PAIR_ELECTRON_NEUTRAL = 1
+_PAIR_NEUTRAL_NEUTRAL = 2
+_PAIR_ION_NEUTRAL = 3
 
 
 def _qe_pair(species_neutral: "Species", T: float) -> dict[int, float]:
@@ -1860,21 +1868,266 @@ def _pair_integrals(
     return out
 
 
+class _CollisionModel:
+    """Numeric, temperature-independent descriptors for every species pair."""
+
+    def __init__(self, species: tuple["Species", ...]):
+        n = len(species)
+        self.kinds = np.empty((n, n), dtype=np.int8)
+        self.charges = np.array([sp.charge_number for sp in species])
+        self.electron_index = next(
+            (i for i, sp in enumerate(species) if sp.name == "e"), -1
+        )
+        self.fit_parameters = np.zeros((n, n, 5))
+        self.electron_parameters = np.zeros((n, 4))
+        self.electron_gamma_ratios = np.zeros((n, 8))
+        self.resonant = np.zeros((n, n), dtype=np.bool_)
+        self.resonant_parameters = np.zeros((n, n, 3))
+
+        for i, sp in enumerate(species):
+            cross_section = getattr(sp, "electron_cross_section", None)
+            if isinstance(cross_section, (tuple, list)):
+                D1, D2, D3, D4 = cross_section
+            elif isinstance(cross_section, float):
+                D1, D2, D3, D4 = cross_section, 0.0, 0.0, 0.0
+            else:
+                continue
+            self.electron_parameters[i] = D1, D2, D3, D4
+            for s in _S_VALUES:
+                self.electron_gamma_ratios[i, s] = gamma(
+                    D3 / 2 + s + 2
+                ) / gamma(s + 2)
+
+        for i, species_i in enumerate(species):
+            for j, species_j in enumerate(species):
+                self._describe_pair(i, species_i, j, species_j)
+
+    def _describe_pair(
+        self,
+        i: int,
+        species_i: "Species",
+        j: int,
+        species_j: "Species",
+    ) -> None:
+        z_i, z_j = species_i.charge_number, species_j.charge_number
+        if z_i != 0 and z_j != 0:
+            self.kinds[i, j] = _PAIR_CHARGED
+            return
+
+        if species_i.name == "e" or species_j.name == "e":
+            self.kinds[i, j] = _PAIR_ELECTRON_NEUTRAL
+            neutral = species_j if species_i.name == "e" else species_i
+            if not isinstance(
+                neutral.electron_cross_section, (tuple, list, float)
+            ):
+                raise ValueError("Invalid electron cross section data.")
+            return
+
+        if z_i == 0 and z_j == 0:
+            self.kinds[i, j] = _PAIR_NEUTRAL_NEUTRAL
+            sigma, epsilon_0, beta_array = _nn_pair_parameters(
+                species_i, species_j
+            )
+        else:
+            self.kinds[i, j] = _PAIR_ION_NEUTRAL
+            ion, neutral = (
+                (species_j, species_i) if z_i == 0 else (species_i, species_j)
+            )
+            sigma, epsilon_0, beta_array = _in_pair_parameters(ion, neutral)
+            if (
+                species_i.stoichiometry == species_j.stoichiometry
+                and abs(z_i - z_j) == 1
+            ):
+                self.resonant[i, j] = True
+                lower = species_i if z_i < z_j else species_j
+                self.resonant_parameters[i, j] = (
+                    A(lower.ionisation_energy),
+                    B(lower.ionisation_energy),
+                    lower.molar_mass,
+                )
+
+        self.fit_parameters[i, j, :2] = sigma, epsilon_0
+        self.fit_parameters[i, j, 2:] = beta_array
+
+    def evaluate(
+        self,
+        number_densities: np.ndarray,
+        T: float,
+        ls_pairs: tuple[tuple[int, int], ...],
+    ) -> dict[tuple[int, int], np.ndarray]:
+        moments = np.asarray(ls_pairs, dtype=np.int64)
+        values = _collision_integrals_kernel(
+            number_densities,
+            T,
+            moments,
+            self.kinds,
+            self.charges,
+            self.electron_index,
+            self.fit_parameters,
+            self.electron_parameters,
+            self.electron_gamma_ratios,
+            self.resonant,
+            self.resonant_parameters,
+        )
+        return {tuple(moment): values[k] for k, moment in enumerate(moments)}
+
+
+@njit
+def _coulomb_logarithm_kernel(
+    i: int,
+    j: int,
+    n_i: float,
+    n_j: float,
+    T: float,
+    charges: np.ndarray,
+    electron_index: int,
+) -> float:
+    """Numeric equivalent of :func:`cl_charged`."""
+    T_eV = T * u.K_to_eV
+    if i == electron_index and j == electron_index:
+        ne_cgs = n_i * 1e-6
+        return (
+            23.5
+            - np.log(ne_cgs ** (1 / 2) * T_eV ** (-5 / 4))
+            - (1e-5 + (np.log(T_eV) - 2) ** 2 / 16) ** (1 / 2)
+        )
+    if i == electron_index:
+        ne_cgs = n_i * 1e-6
+        return 23 - np.log(
+            ne_cgs ** (1 / 2) * abs(charges[j]) * T_eV ** (-3 / 2)
+        )
+    if j == electron_index:
+        ne_cgs = n_j * 1e-6
+        return 23 - np.log(
+            ne_cgs ** (1 / 2) * abs(charges[i]) * T_eV ** (-3 / 2)
+        )
+    ni_cgs, nj_cgs = n_i * 1e-6, n_j * 1e-6
+    z_i, z_j = charges[i], charges[j]
+    return 23 - np.log(
+        abs(z_i * z_j)
+        / T_eV
+        * (ni_cgs * abs(z_i) ** 2 / T_eV + nj_cgs * abs(z_j) ** 2 / T_eV)
+        ** (1 / 2)
+    )
+
+
+@njit
+def _collision_integrals_kernel(
+    number_densities: np.ndarray,
+    T: float,
+    moments: np.ndarray,
+    kinds: np.ndarray,
+    charges: np.ndarray,
+    electron_index: int,
+    fit_parameters: np.ndarray,
+    electron_parameters: np.ndarray,
+    electron_gamma_ratios: np.ndarray,
+    resonant: np.ndarray,
+    resonant_parameters: np.ndarray,
+) -> np.ndarray:
+    """Evaluate all requested collision moments in one compiled pair loop."""
+    n = number_densities.size
+    values = np.empty((moments.shape[0], n, n))
+    log_two = np.log(2.0)
+
+    for i in range(n):
+        for j in range(n):
+            kind = kinds[i, j]
+
+            if kind == _PAIR_CHARGED:
+                b0_sq = (
+                    ke * charges[i] * charges[j] * u.e**2 / (2 * u.k_b * T)
+                ) ** 2
+                cl = (
+                    _coulomb_logarithm_kernel(
+                        i,
+                        j,
+                        number_densities[i],
+                        number_densities[j],
+                        T,
+                        charges,
+                        electron_index,
+                    )
+                    + log_two
+                )
+                for k in range(moments.shape[0]):
+                    l, s = moments[k]
+                    values[k, i, j] = (
+                        _QC_C1[l - 1]
+                        * np.pi
+                        / (s * (s + 1))
+                        * b0_sq
+                        * (
+                            cl
+                            - _QC_C2[l - 1]
+                            - 2 * egamma
+                            + _PSICONST_ARRAY[s]
+                        )
+                    )
+                continue
+
+            if kind == _PAIR_ELECTRON_NEUTRAL:
+                neutral = j if i == electron_index else i
+                D1, D2, D3, D4 = electron_parameters[neutral]
+                tau = np.sqrt(2 * u.m_e * u.k_b * T) / u.hbar
+                tau_pow = tau**D3
+                tau_sq = D4 * tau**2 + 1
+                for k in range(moments.shape[0]):
+                    s = moments[k, 1]
+                    barg = D3 / 2 + s + 2
+                    values[k, i, j] = (
+                        D1
+                        + D2
+                        * tau_pow
+                        * electron_gamma_ratios[neutral, s]
+                        / tau_sq**barg
+                    )
+                continue
+
+            sigma = fit_parameters[i, j, 0]
+            epsilon_0 = fit_parameters[i, j, 1]
+            beta_array = fit_parameters[i, j, 2:]
+            for k in range(moments.shape[0]):
+                l, s = moments[k]
+                if kind == _PAIR_NEUTRAL_NEUTRAL:
+                    values[k, i, j] = _omega_fit(
+                        c_nn, sigma, epsilon_0, beta_array, l, s, T
+                    )
+                elif resonant[i, j] and l % 2 == 1:
+                    a, b, molar_mass = resonant_parameters[i, j]
+                    ln_term = np.log(4 * u.R * T / molar_mass)
+                    zeta_1 = _SUM1_ARRAY[s]
+                    zeta_2 = _SUM2_ARRAY[s]
+                    cterm = np.pi**2 / 6 - zeta_2 + zeta_1**2
+                    values[k, i, j] = (
+                        a**2
+                        - zeta_1 * a * b
+                        + (b / 2) ** 2 * cterm
+                        + (b / 2) ** 2 * ln_term**2
+                        + (zeta_1 * b**2 / 2 - a * b) * ln_term
+                    )
+                else:
+                    values[k, i, j] = _omega_fit(
+                        c_in, sigma, epsilon_0, beta_array, l, s, T
+                    )
+    return values
+
+
 def collision_integrals(
     mixture: "LTE",
     ls_pairs: tuple[tuple[int, int], ...] = LS_PAIRS,
 ) -> dict[tuple[int, int], np.ndarray]:
     r"""Collision integral matrices for the requested (l, s) pairs.
 
-    Evaluated together, species pairs outermost and moments innermost, so
-    that each pair's interaction-potential parameters -- equilibrium
-    distance, binding energy, beta, the Coulomb logarithm -- are derived
-    once for the pair rather than once per (l, s).
+    Evaluated together in one compiled pair loop. Temperature-independent
+    numeric descriptors -- interaction-potential parameters and resonant
+    charge-transfer coefficients -- are retained by the mixture. The
+    temperature- and composition-dependent matrices are freshly evaluated.
 
-    Nothing is cached.  Callers that need the same set more than once
-    should evaluate it here and pass it on: :func:`q` and :func:`qhat` both
-    accept it as ``Q``, and :func:`q`'s result can in turn be passed to
-    :func:`Dij` and :func:`DTi` as ``qq``.
+    Callers that need the same matrices more than once should evaluate them
+    here and pass them on: :func:`q` and :func:`qhat` both accept them as
+    ``Q``, and :func:`q`'s result can in turn be passed to :func:`Dij` and
+    :func:`DTi` as ``qq``.
 
     Parameters
     ----------
@@ -1890,27 +2143,10 @@ def collision_integrals(
     dict[tuple[int, int], np.ndarray]
         Collision integral matrix for each requested (l, s) pair.
     """
-    nb_species = len(mixture.species)
     state = mixture._equilibrium_state()
-    number_densities = state.number_densities
-    values = {ls: np.zeros((nb_species, nb_species)) for ls in ls_pairs}
-
-    # Species pairs outermost, moments innermost: the potential parameters
-    # are a property of the pair, so this derives them once each rather than
-    # once per (l, s).
-    for i, (ndi, species_i) in enumerate(
-        zip(number_densities, mixture.species)
-    ):
-        for j, (ndj, species_j) in enumerate(
-            zip(number_densities, mixture.species)
-        ):
-            pair = _pair_integrals(
-                species_i, ndi, species_j, ndj, mixture.T, ls_pairs
-            )
-            for ls, value in pair.items():
-                values[ls][i, j] = value
-
-    return values
+    return mixture._collision_model().evaluate(
+        state.number_densities, state.T, ls_pairs
+    )
 
 
 def Qij_mix(mixture: "LTE", l: int, s: int) -> np.ndarray:

--- a/src/minplascalc/functions_transport.py
+++ b/src/minplascalc/functions_transport.py
@@ -3289,11 +3289,10 @@ def thermal_conductivity(
     # Compute the derivative of the number densities with respect to
     # temperature. x is the concentration of species i, x = ni / ntot
     Tval = mixture.T
-    mixture.T = Tval * (1 + rel_delta_T)
-    n_positive = mixture.calculate_composition()
-    mixture.T = Tval * (1 - rel_delta_T)
-    n_negative = mixture.calculate_composition()
-    mixture.T = Tval
+    with mixture._at_temperature(Tval * (1 + rel_delta_T)):
+        n_positive = mixture.calculate_composition()
+    with mixture._at_temperature(Tval * (1 - rel_delta_T)):
+        n_negative = mixture.calculate_composition()
     x_positive = n_positive / np.sum(n_positive)
     x_negative = n_negative / np.sum(n_negative)
     dxdT = (x_positive - x_negative) / (2 * rel_delta_T * mixture.T)

--- a/src/minplascalc/functions_transport.py
+++ b/src/minplascalc/functions_transport.py
@@ -1889,7 +1889,8 @@ def collision_integrals(
         Collision integral matrix for each requested (l, s) pair.
     """
     nb_species = len(mixture.species)
-    number_densities = mixture.calculate_composition()  # in m^-3
+    state = mixture._equilibrium_state()
+    number_densities = state.number_densities
     values = {ls: np.zeros((nb_species, nb_species)) for ls in ls_pairs}
 
     # Species pairs outermost, moments innermost: the potential parameters
@@ -1934,7 +1935,7 @@ def Qij_mix(mixture: "LTE", l: int, s: int) -> np.ndarray:
     # Square matrix to store the collision integrals.
     Q_values = np.zeros((len(mixture.species), len(mixture.species)))
     # Get the number densities of the species in the mixture.
-    number_densities = mixture.calculate_composition()  # in m^-3
+    number_densities = mixture._equilibrium_state().number_densities
 
     # For all pairs of species in the mixture, calculate the corresponding
     # collision integral.
@@ -1981,8 +1982,9 @@ def q(
     [Devoto1966]_.
     """
     nb_species = len(mixture.species)
-    number_densities = mixture.calculate_composition()  # m^-3
-    masses = mixture.masses  # kg
+    state = mixture._equilibrium_state()
+    number_densities = state.number_densities
+    masses = state.masses
 
     if Q is None:
         Q = collision_integrals(mixture)
@@ -2628,8 +2630,9 @@ def qhat(
     [Devoto1966]_, from equation A19 to A22.
     """
     nb_species = len(mixture.species)
-    number_densities = mixture.calculate_composition()
-    masses = mixture.masses
+    state = mixture._equilibrium_state()
+    number_densities = state.number_densities
+    masses = state.masses
 
     # qhat()'s (l, s) set is a subset of q()'s, so a set computed for q()
     # can be reused here.
@@ -2813,11 +2816,11 @@ def Dij(mixture: "LTE", qq: np.ndarray | None = None) -> np.ndarray:
     TODO: Why not use equation 8?
     """
     nb_species = len(mixture.species)
-    number_densities = mixture.calculate_composition()  # m^-3
-    masses = mixture.masses  # kg
-    rho = mixture.calculate_density()  # kg/m^3
-
-    n_tot = np.sum(number_densities)  # m^-3
+    state = mixture._equilibrium_state()
+    number_densities = state.number_densities
+    masses = state.masses
+    rho = state.rho
+    n_tot = state.n_tot
 
     if qq is None:
         qq = q(mixture)  # Size (4*nb_species, 4*nb_species)
@@ -2906,8 +2909,9 @@ def DTi(mixture: "LTE", qq: np.ndarray | None = None) -> float:
     TODO: Why not use equation 9?
     """
     nb_species = len(mixture.species)
-    number_densities = mixture.calculate_composition()
-    masses = mixture.masses
+    state = mixture._equilibrium_state()
+    number_densities = state.number_densities
+    masses = state.masses
 
     if qq is None:
         qq = q(mixture)
@@ -2981,8 +2985,9 @@ def viscosity(mixture: "LTE") -> float:
     TODO: Why not use equation 21?
     """
     nb_species = len(mixture.species)
-    number_densities = mixture.calculate_composition()
-    masses = mixture.masses
+    state = mixture._equilibrium_state()
+    number_densities = state.number_densities
+    masses = state.masses
 
     qqhat = qhat(mixture)
 
@@ -3041,13 +3046,14 @@ def electrical_conductivity(mixture: "LTE") -> float:
     """
     # This function should only be called for electron-containing mixtures
     # Non-electron mixtures should return 0 via their template method override
-    charge_numbers = mixture.charge_numbers
-    number_densities = mixture.calculate_composition()
-    masses = mixture.masses
-    rho = mixture.calculate_density()
+    state = mixture._equilibrium_state()
+    charge_numbers = state.charge_numbers
+    number_densities = state.number_densities
+    masses = state.masses
+    rho = state.rho
 
     D1 = Dij(mixture)[-1, :]
-    n_tot = np.sum(number_densities)
+    n_tot = state.n_tot
 
     # TODO: Check if this is correct. Electrons should be discarded.
     # TODO: Check if this is correct. Neutral species should be discarded
@@ -3176,16 +3182,16 @@ def thermal_conductivity(
               a_{j 1}
     """
     nb_species = len(mixture.species)
-    number_densities = mixture.calculate_composition()
-    masses = mixture.masses
-    n_tot = np.sum(number_densities)
-    rho = mixture.calculate_density()
+    state = mixture._equilibrium_state()
+    number_densities = state.number_densities
+    masses = state.masses
+    n_tot = state.n_tot
+    rho = state.rho
     hv = mixture.calculate_species_enthalpies()
 
     # Rescale species enthalpies relative to average molar mass.
     # TODO: why?
-    average_molar_mass = rho / n_tot
-    hv = hv * masses / average_molar_mass
+    hv = hv * masses / state.mean_particle_mass
 
     ### translational tk components ###
     # Solve equation 5 of [Devoto1966]_ to get the `a` matrix.

--- a/src/minplascalc/functions_transport.py
+++ b/src/minplascalc/functions_transport.py
@@ -2752,7 +2752,72 @@ def _qhat11_jit(
 ### Transport property calculations ###########################################
 
 
-def Dij(mixture: "LTE", qq: np.ndarray | None = None) -> np.ndarray:
+class _QSystem:
+    """Factorized Devoto q-system and its shared solution families."""
+
+    def __init__(self, mixture: "LTE", qq: np.ndarray | None = None):
+        self.state = mixture._equilibrium_state()
+        self.nb_species = len(mixture.species)
+        self.qq = q(mixture) if qq is None else qq
+        self.lu_piv = scl.lu_factor(self.qq)
+        self._aip: np.ndarray | None = None
+        self._c_unit: np.ndarray | None = None
+
+    @property
+    def aip(self) -> np.ndarray:
+        """Coefficients solving equation 5 of [Devoto1966]."""
+        if self._aip is None:
+            b_vec = np.zeros(4 * self.nb_species)
+            b_vec[self.nb_species : 2 * self.nb_species] = (
+                -15 / 2 * np.sqrt(np.pi) * self.state.number_densities
+            )
+            self._aip = scl.lu_solve(self.lu_piv, b_vec).reshape(
+                4, self.nb_species
+            )
+        return self._aip
+
+    @property
+    def c_unit(self) -> np.ndarray:
+        """Equation-6 solutions for the independent unit-vector RHSs."""
+        if self._c_unit is None:
+            b_matrix = np.zeros((4 * self.nb_species, self.nb_species))
+            b_matrix[: self.nb_species, :] = (
+                3 * np.sqrt(np.pi) * np.eye(self.nb_species)
+            )
+            self._c_unit = scl.lu_solve(self.lu_piv, b_matrix)[
+                : self.nb_species
+            ]
+        return self._c_unit
+
+    def thermal_diffusion(self) -> np.ndarray:
+        """Thermal diffusion coefficients from the shared ``a`` solution."""
+        state = self.state
+        return (
+            0.5
+            * state.number_densities
+            * state.masses
+            * np.sqrt(2 * u.k_b * state.T / state.masses)
+            * self.aip[0]
+        )
+
+    def diffusion_matrix(self) -> np.ndarray:
+        """Ordinary diffusion coefficients from the shared unit solutions."""
+        state = self.state
+        cip0 = np.diag(self.c_unit)[:, np.newaxis] - self.c_unit
+        return (
+            state.rho
+            * state.number_densities[:, np.newaxis]
+            / (2 * state.n_tot * state.masses[np.newaxis, :])
+            * np.sqrt(2 * u.k_b * state.T / state.masses)[:, np.newaxis]
+            * cip0
+        )
+
+
+def Dij(
+    mixture: "LTE",
+    qq: np.ndarray | None = None,
+    q_system: _QSystem | None = None,
+) -> np.ndarray:
     r"""Diffusion coefficients.
 
     Diffusion coefficents, calculation per [Devoto1966]_ (eq. 3 and eq. 6).
@@ -2815,42 +2880,15 @@ def Dij(mixture: "LTE", qq: np.ndarray | None = None) -> np.ndarray:
     TODO: Add how the code works.
     TODO: Why not use equation 8?
     """
-    nb_species = len(mixture.species)
-    state = mixture._equilibrium_state()
-    number_densities = state.number_densities
-    masses = state.masses
-    rho = state.rho
-    n_tot = state.n_tot
-
-    if qq is None:
-        qq = q(mixture)  # Size (4*nb_species, 4*nb_species)
-    lu_piv_q = scl.lu_factor(qq)
-
-    # Equation 6 of [Devoto1966]_.  The right-hand side for the pair (i, j)
-    # is 3 sqrt(pi) (e_i - e_j) in its first nb_species entries, so the
-    # nb_species**2 right-hand sides span only an nb_species-dimensional
-    # space.  Solving once against the unit vectors therefore gives every
-    # c^{ji} by subtraction, instead of one solve per pair.
-    b_matrix = np.zeros((4 * nb_species, nb_species))
-    b_matrix[:nb_species, :] = 3 * np.sqrt(np.pi) * np.eye(nb_species)
-    c_unit = scl.lu_solve(lu_piv_q, b_matrix)[:nb_species]
-
-    # c_i0^{ji} for the pair (i, j) is c_unit[i, i] - c_unit[i, j].
-    cip0 = np.diag(c_unit)[:, np.newaxis] - c_unit
-
-    # Diffusion coefficient, equation 3 of [Devoto1966]_.
-    diffusion_matrix = (
-        rho
-        * number_densities[:, np.newaxis]
-        / (2 * n_tot * masses[np.newaxis, :])
-        * np.sqrt(2 * u.k_b * mixture.T / masses)[:, np.newaxis]
-        * cip0
-    )
-
-    return diffusion_matrix
+    system = q_system or _QSystem(mixture, qq)
+    return system.diffusion_matrix()
 
 
-def DTi(mixture: "LTE", qq: np.ndarray | None = None) -> float:
+def DTi(
+    mixture: "LTE",
+    qq: np.ndarray | None = None,
+    q_system: _QSystem | None = None,
+) -> np.ndarray:
     r"""Thermal diffusion coefficients.
 
     Thermal diffusion coefficents, calculation per [Devoto1966]_
@@ -2908,28 +2946,8 @@ def DTi(mixture: "LTE", qq: np.ndarray | None = None) -> float:
     TODO: Add how the code works.
     TODO: Why not use equation 9?
     """
-    nb_species = len(mixture.species)
-    state = mixture._equilibrium_state()
-    number_densities = state.number_densities
-    masses = state.masses
-
-    if qq is None:
-        qq = q(mixture)
-    b_vec = np.zeros(4 * nb_species)  # 4 for 4th order approximation
-    # Only the first element is non-zero
-    b_vec[nb_species : 2 * nb_species] = (
-        -15 / 2 * np.sqrt(np.pi) * number_densities
-    )
-    aflat = np.linalg.solve(qq, b_vec)
-    aip = aflat.reshape(4, nb_species)
-
-    return (
-        0.5
-        * number_densities
-        * masses
-        * np.sqrt(2 * u.k_b * mixture.T / masses)
-        * aip[0]
-    )
+    system = q_system or _QSystem(mixture, qq)
+    return system.thermal_diffusion()
 
 
 def viscosity(mixture: "LTE") -> float:
@@ -3200,12 +3218,8 @@ def thermal_conductivity(
     # down restore T before Dij is called).
     qq = q(mixture)
 
-    b_vec = np.zeros(4 * nb_species)
-    b_vec[nb_species : 2 * nb_species] = (
-        -15 / 2 * np.sqrt(np.pi) * number_densities
-    )
-    aflat = np.linalg.solve(qq, b_vec)
-    aip = aflat.reshape(4, nb_species)
+    q_system = _QSystem(mixture, qq)
+    aip = q_system.aip
     # Equation 13 of [Devoto1966]_.
     k_dash = (
         -5
@@ -3222,7 +3236,7 @@ def thermal_conductivity(
         # TODO: This looks like the second term in the second parenthesis of 18
         # of [Devoto1966]_.
         # TODO: Check if it is correct. Where are the term n² and rho?
-        locDTi = DTi(mixture, qq=qq)
+        locDTi = q_system.thermal_diffusion()
         kdt = np.sum(hv * locDTi / mixture.T)
     else:
         kdt = 0
@@ -3241,7 +3255,7 @@ def thermal_conductivity(
     x_negative = n_negative / np.sum(n_negative)
     dxdT = (x_positive - x_negative) / (2 * rel_delta_T * mixture.T)
 
-    locDij = Dij(mixture, qq=qq)
+    locDij = q_system.diffusion_matrix()
 
     # TODO: This looks like the first term in the first parenthesis of
     # 18 of [Devoto1966]_.

--- a/src/minplascalc/mixture.py
+++ b/src/minplascalc/mixture.py
@@ -5,6 +5,7 @@ This includes species composition and thermodynamic properties.
 
 import logging
 import warnings
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -13,6 +14,26 @@ from minplascalc import species as _sp
 from minplascalc import units as u
 
 __all__ = ["lte_from_names", "LTE", "LTEWithoutElectrons"]
+
+
+@dataclass(frozen=True)
+class _EquilibriumState:
+    """Derived quantities for one converged mixture state."""
+
+    T: float
+    P: float
+    particle_numbers: np.ndarray
+    number_densities: np.ndarray
+    mole_fractions: np.ndarray
+    masses: np.ndarray
+    charge_numbers: np.ndarray
+    reference_energies: np.ndarray
+    ionization_lowering: np.ndarray
+    kbt: float
+    volume: float
+    n_tot: float
+    rho: float
+    mean_particle_mass: float
 
 
 class LTE:
@@ -101,6 +122,7 @@ class LTE:
 
         # Number of particles of each species.
         self.__Ni: np.ndarray = np.zeros(len(self.species))
+        self.__state: _EquilibriumState | None = None
 
     @property
     def species(self):
@@ -132,6 +154,7 @@ class LTE:
     def x0(self, x0):
         self._validate_x0_length(x0)
         self.__isLTE = False
+        self.__state = None
         self.__x0 = self._format_x0(x0)
 
     @property
@@ -141,6 +164,7 @@ class LTE:
     @T.setter
     def T(self, T):
         self.__isLTE = False  # Reset LTE composition flag.
+        self.__state = None
         self.__T = T
 
     @property
@@ -150,6 +174,7 @@ class LTE:
     @P.setter
     def P(self, P):
         self.__isLTE = False  # Reset LTE composition flag.
+        self.__state = None
         self.__P = P
 
     def __repr__(self):
@@ -684,11 +709,43 @@ class LTE:
         logging.debug(self.__Ni)
 
         self.__isLTE = True
+        self.__state = None
 
         N_i = self.__Ni  # Number of particles of each species.
         N_tot = N_i.sum()  # Total number of particles in the plasma.
         V = N_tot * kbt / self.P  # Volume of the plasma, in m3.
         return N_i / V  # Number density of each species, in particles/m3.
+
+    def _equilibrium_state(self) -> _EquilibriumState:
+        """Return all commonly used quantities for the current LTE state."""
+        if self.__state is not None:
+            return self.__state
+
+        number_densities = self.calculate_composition()
+        kbt = u.k_b * self.T
+        particle_numbers = self.__Ni
+        particle_total = particle_numbers.sum()
+        volume = particle_total * kbt / self.P
+        n_tot = number_densities.sum()
+        rho = number_densities @ self.masses
+
+        self.__state = _EquilibriumState(
+            T=self.T,
+            P=self.P,
+            particle_numbers=particle_numbers,
+            number_densities=number_densities,
+            mole_fractions=number_densities / n_tot,
+            masses=self.masses,
+            charge_numbers=self.charge_numbers,
+            reference_energies=self.__E0,
+            ionization_lowering=self.__dE,
+            kbt=kbt,
+            volume=volume,
+            n_tot=n_tot,
+            rho=rho,
+            mean_particle_mass=rho / n_tot,
+        )
+        return self.__state
 
     def calculate_density(self) -> float:
         r"""Calculate the LTE density of the plasma.
@@ -715,13 +772,7 @@ class LTE:
         * :math:`M_i` is the molar mass of species :math:`i`,
           in :math:`\text{kg.mol}^{-1}`.
         """
-        number_densities = self.calculate_composition()  # particles/m^3
-        molar_masses = [sp.molar_mass for sp in self.species]  # kg/mol
-        # kg/m3 = (particules/m^3 * kg/mol) / (particules/mol)
-        return (
-            sum(n_i * M_i for n_i, M_i in zip(number_densities, molar_masses))
-            / u.N_a
-        )
+        return self._equilibrium_state().rho
 
     def calculate_species_enthalpies(self) -> np.ndarray:
         r"""Calculate the LTE enthalpy for each component in the plasma.
@@ -768,14 +819,15 @@ class LTE:
         * :math:`M_i` is the molar mass of species :math:`i`,
           in :math:`\text{kg.mol}^{-1}`.
         """
+        state = self._equilibrium_state()
         internal_energies = [
-            sp.internal_energy(self.T, dE)
-            for sp, dE in zip(self.species, self.__dE)
+            sp.internal_energy(state.T, dE)
+            for sp, dE in zip(self.species, state.ionization_lowering)
         ]  # J/particle
 
         enthalpies = [
-            (u_i + E0_i + u.k_b * self.T)
-            for u_i, E0_i in zip(internal_energies, self.__E0)
+            (u_i + E0_i + state.kbt)
+            for u_i, E0_i in zip(internal_energies, state.reference_energies)
         ]  # J/particle
 
         # (kg/mol) / (particle/mol) = kg/particle
@@ -815,10 +867,11 @@ class LTE:
         * :math:`M_i` is the molar mass of species :math:`i`,
           in :math:`\text{kg.mol}^{-1}`.
         """
-        number_densities = self.calculate_composition()  # m^-3
+        state = self._equilibrium_state()
+        number_densities = state.number_densities
         molar_masses = [sp.molar_mass for sp in self.species]  # kg/mol
 
-        density = self.calculate_density()  # kg/m3
+        density = state.rho
 
         mass_enthalpies = self.calculate_species_enthalpies()  # J/kg
         masses = self.masses  # kg/particle
@@ -826,9 +879,11 @@ class LTE:
 
         # Get the species with the lowest reference energy.
         # Index of the species with the lowest reference energy.
-        i_min = np.argmin(self.__E0)
+        i_min = np.argmin(state.reference_energies)
         # J/(kg/mol)
-        h_mol_0 = self.__E0[i_min] / self.species[i_min].molar_mass
+        h_mol_0 = (
+            state.reference_energies[i_min] / self.species[i_min].molar_mass
+        )
 
         weighted_enthalpy = sum(
             n_i * (h_i - h_mol_0 * M_i)

--- a/src/minplascalc/mixture.py
+++ b/src/minplascalc/mixture.py
@@ -126,6 +126,7 @@ class LTE:
         self.__Ni: np.ndarray = np.zeros(len(self.species))
         self.__state: _EquilibriumState | None = None
         self.__transport_workspace = None
+        self.__collision_model = None
 
     @property
     def species(self):
@@ -760,6 +761,14 @@ class LTE:
                 functions_transport._TransportWorkspace(self)
             )
         return self.__transport_workspace
+
+    def _collision_model(self):
+        """Return temperature-independent numeric collision descriptors."""
+        if self.__collision_model is None:
+            self.__collision_model = functions_transport._CollisionModel(
+                self.species
+            )
+        return self.__collision_model
 
     @contextmanager
     def _at_temperature(self, T: float) -> Iterator[None]:

--- a/src/minplascalc/mixture.py
+++ b/src/minplascalc/mixture.py
@@ -123,6 +123,7 @@ class LTE:
         # Number of particles of each species.
         self.__Ni: np.ndarray = np.zeros(len(self.species))
         self.__state: _EquilibriumState | None = None
+        self.__transport_workspace = None
 
     @property
     def species(self):
@@ -155,6 +156,7 @@ class LTE:
         self._validate_x0_length(x0)
         self.__isLTE = False
         self.__state = None
+        self.__transport_workspace = None
         self.__x0 = self._format_x0(x0)
 
     @property
@@ -165,6 +167,7 @@ class LTE:
     def T(self, T):
         self.__isLTE = False  # Reset LTE composition flag.
         self.__state = None
+        self.__transport_workspace = None
         self.__T = T
 
     @property
@@ -175,6 +178,7 @@ class LTE:
     def P(self, P):
         self.__isLTE = False  # Reset LTE composition flag.
         self.__state = None
+        self.__transport_workspace = None
         self.__P = P
 
     def __repr__(self):
@@ -746,6 +750,14 @@ class LTE:
             mean_particle_mass=rho / n_tot,
         )
         return self.__state
+
+    def _transport_workspace(self):
+        """Return lazily evaluated transport intermediates for this state."""
+        if self.__transport_workspace is None:
+            self.__transport_workspace = (
+                functions_transport._TransportWorkspace(self)
+            )
+        return self.__transport_workspace
 
     def calculate_density(self) -> float:
         r"""Calculate the LTE density of the plasma.

--- a/src/minplascalc/mixture.py
+++ b/src/minplascalc/mixture.py
@@ -111,6 +111,10 @@ class LTE:
             [sp.charge_number for sp in self.__species]
         )
 
+        self.__state: _EquilibriumState | None = None
+        self.__transport_workspace = None
+        self.__collision_model = None
+
         self.x0 = x0
         self.T = T
         self.P = P
@@ -124,9 +128,6 @@ class LTE:
 
         # Number of particles of each species.
         self.__Ni: np.ndarray = np.zeros(len(self.species))
-        self.__state: _EquilibriumState | None = None
-        self.__transport_workspace = None
-        self.__collision_model = None
 
     @property
     def species(self):
@@ -157,10 +158,8 @@ class LTE:
     @x0.setter
     def x0(self, x0):
         self._validate_x0_length(x0)
-        self.__isLTE = False
-        self.__state = None
-        self.__transport_workspace = None
         self.__x0 = self._format_x0(x0)
+        self._invalidate_equilibrium()
 
     @property
     def T(self):
@@ -168,10 +167,8 @@ class LTE:
 
     @T.setter
     def T(self, T):
-        self.__isLTE = False  # Reset LTE composition flag.
-        self.__state = None
-        self.__transport_workspace = None
         self.__T = T
+        self._invalidate_equilibrium()
 
     @property
     def P(self):
@@ -179,10 +176,41 @@ class LTE:
 
     @P.setter
     def P(self, P):
-        self.__isLTE = False  # Reset LTE composition flag.
+        self.__P = P
+        self._invalidate_equilibrium()
+
+    @property
+    def gfe_initial_particles(self):
+        return self.__gfe_initial_particles
+
+    @gfe_initial_particles.setter
+    def gfe_initial_particles(self, value):
+        self.__gfe_initial_particles = value
+        self._invalidate_equilibrium()
+
+    @property
+    def gfe_rtol(self):
+        return self.__gfe_rtol
+
+    @gfe_rtol.setter
+    def gfe_rtol(self, value):
+        self.__gfe_rtol = value
+        self._invalidate_equilibrium()
+
+    @property
+    def gfe_max_iter(self):
+        return self.__gfe_max_iter
+
+    @gfe_max_iter.setter
+    def gfe_max_iter(self, value):
+        self.__gfe_max_iter = value
+        self._invalidate_equilibrium()
+
+    def _invalidate_equilibrium(self) -> None:
+        """Discard quantities derived from mutable mixture inputs."""
+        self.__isLTE = False
         self.__state = None
         self.__transport_workspace = None
-        self.__P = P
 
     def __repr__(self):
         return (

--- a/src/minplascalc/mixture.py
+++ b/src/minplascalc/mixture.py
@@ -5,7 +5,9 @@ This includes species composition and thermodynamic properties.
 
 import logging
 import warnings
+from contextlib import contextmanager
 from dataclasses import dataclass
+from typing import Iterator
 
 import numpy as np
 
@@ -759,6 +761,33 @@ class LTE:
             )
         return self.__transport_workspace
 
+    @contextmanager
+    def _at_temperature(self, T: float) -> Iterator[None]:
+        """Temporarily change temperature, restoring the complete LTE state."""
+        self._equilibrium_state()
+        original = (
+            self.__T,
+            self.__isLTE,
+            self.__Ni,
+            self.__E0,
+            self.__dE,
+            self.__state,
+            self.__transport_workspace,
+        )
+        self.T = T
+        try:
+            yield
+        finally:
+            (
+                self.__T,
+                self.__isLTE,
+                self.__Ni,
+                self.__E0,
+                self.__dE,
+                self.__state,
+                self.__transport_workspace,
+            ) = original
+
     def calculate_density(self) -> float:
         r"""Calculate the LTE density of the plasma.
 
@@ -947,11 +976,10 @@ class LTE:
         * :math:`\Delta T` is the relative change in temperature.
         """
         start_temperature = self.T
-        self.T = start_temperature * (1 - rel_delta_T)
-        enthalpy_low = self.calculate_enthalpy()
-        self.T = start_temperature * (1 + rel_delta_T)
-        enthalpy_high = self.calculate_enthalpy()
-        self.T = start_temperature
+        with self._at_temperature(start_temperature * (1 - rel_delta_T)):
+            enthalpy_low = self.calculate_enthalpy()
+        with self._at_temperature(start_temperature * (1 + rel_delta_T)):
+            enthalpy_high = self.calculate_enthalpy()
         return (enthalpy_high - enthalpy_low) / (2 * rel_delta_T * self.T)
 
     def calculate_viscosity(self) -> float:

--- a/src/minplascalc/species.py
+++ b/src/minplascalc/species.py
@@ -312,6 +312,16 @@ class Monatomic(Species):
             f"Emission lines: {len(self.emission_lines)}"
         )
 
+    def _electronic_moments(self, T: float, dE: float) -> tuple[float, float]:
+        """Electronic partition sum and its energy-weighted first moment."""
+        beta = 1 / (u.k_b * T)
+        below = self._level_energies < (self.ionisation_energy - dE)
+        weights = self._degeneracies * below
+        boltzmann = np.exp(-beta * self._level_energies)
+        return float(weights @ boltzmann), float(
+            (weights * self._level_energies) @ boltzmann
+        )
+
     def internal_partition_function(self, T: float, dE: float) -> float:
         r"""Calculate the internal partition function for an atomic species.
 
@@ -354,16 +364,8 @@ class Monatomic(Species):
 
             g_i = 2J_i + 1
         """
-        beta = 1 / (u.k_b * T)  # Inverse temperature, in J^-1.
-
-        # Only include energy levels below the lowered ionisation energy.
-        # Levels above it are zeroed rather than skipped, so the sum does
-        # not depend on the order of energy_levels.
-        below = self._level_energies < (self.ionisation_energy - dE)
-
-        return float(
-            (self._degeneracies * below) @ np.exp(-beta * self._level_energies)
-        )
+        partition, _ = self._electronic_moments(T, dE)
+        return partition
 
     def internal_energy(self, T: float, dE: float) -> float:
         r"""Calculate the internal energy of an atomic species.
@@ -410,21 +412,11 @@ class Monatomic(Species):
         TODO: Check this --> The internal energy is defined as the sum of the
             translational energy and the electronic energy.
         """
-        beta = 1 / (u.k_b * T)  # Inverse temperature, in J^-1.
-
         # Calculate the translational energy.
         translational_energy = 3 / 2 * u.k_b * T
 
-        # Calculate the electronic energy.  As in
-        # internal_partition_function, levels at or above the lowered
-        # ionisation energy are zeroed rather than terminating the sum.
-        below = self._level_energies < (self.ionisation_energy - dE)
-        electronic_energy = float(
-            (self._degeneracies * self._level_energies * below)
-            @ np.exp(-beta * self._level_energies)
-        )
-
-        electronic_energy /= self.internal_partition_function(T, dE)
+        partition, energy_moment = self._electronic_moments(T, dE)
+        electronic_energy = energy_moment / partition
         return translational_energy + electronic_energy
 
 

--- a/tests/test_collision_kernel.py
+++ b/tests/test_collision_kernel.py
@@ -1,0 +1,63 @@
+"""Numerical equivalence checks for the compiled collision-pair kernel."""
+
+import numpy as np
+import pytest
+
+import minplascalc as mpc
+from minplascalc import functions_transport as ft
+
+SPECIES = [
+    "O2",
+    "O2+",
+    "O",
+    "O+",
+    "O++",
+    "CO",
+    "CO+",
+    "C",
+    "C+",
+    "C++",
+    "SiO",
+    "SiO+",
+    "Si",
+    "Si+",
+    "Si++",
+]
+
+
+@pytest.mark.parametrize("T", [2000.0, 12000.0, 25000.0])
+def test_collision_kernel_matches_scalar_pair_evaluation(T):
+    mixture = mpc.mixture.lte_from_names(
+        SPECIES,
+        x0=[0, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0],
+        T=T,
+        P=101325.0,
+    )
+    state = mixture._equilibrium_state()
+    actual = mixture._collision_model().evaluate(
+        state.number_densities, T, ft.LS_PAIRS
+    )
+
+    n = len(mixture.species)
+    expected = {
+        moment: np.empty((n, n), dtype=np.float64) for moment in ft.LS_PAIRS
+    }
+    for i, (n_i, species_i) in enumerate(
+        zip(state.number_densities, mixture.species)
+    ):
+        for j, (n_j, species_j) in enumerate(
+            zip(state.number_densities, mixture.species)
+        ):
+            pair = ft._pair_integrals(
+                species_i,
+                n_i,
+                species_j,
+                n_j,
+                T,
+                ft.LS_PAIRS,
+            )
+            for moment, value in pair.items():
+                expected[moment][i, j] = value
+
+    for moment in ft.LS_PAIRS:
+        assert actual[moment] == pytest.approx(expected[moment], rel=3e-15)

--- a/tests/test_equilibrium_state.py
+++ b/tests/test_equilibrium_state.py
@@ -1,0 +1,52 @@
+"""Tests for consolidated equilibrium-state caching."""
+
+import pytest
+
+import minplascalc as mpc
+
+
+@pytest.fixture
+def oxygen_mixture():
+    return mpc.mixture.lte_from_names(
+        ["O2", "O", "O+"],
+        x0=[1.0, 0.0, 0.0],
+        T=10_000.0,
+        P=101_325.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "attribute, value",
+    [
+        ("T", 10_100.0),
+        ("P", 202_650.0),
+        ("x0", [0.8, 0.2, 0.0]),
+        ("gfe_initial_particles", 2e20),
+        ("gfe_rtol", 2e-10),
+        ("gfe_max_iter", 999),
+    ],
+)
+def test_mutable_inputs_invalidate_derived_state(
+    oxygen_mixture, attribute, value
+):
+    original_state = oxygen_mixture._equilibrium_state()
+    original_workspace = oxygen_mixture._transport_workspace()
+
+    setattr(oxygen_mixture, attribute, value)
+
+    assert oxygen_mixture._equilibrium_state() is not original_state
+    assert oxygen_mixture._transport_workspace() is not original_workspace
+
+
+def test_temporary_temperature_restores_cached_state(oxygen_mixture):
+    original_state = oxygen_mixture._equilibrium_state()
+    original_workspace = oxygen_mixture._transport_workspace()
+
+    with oxygen_mixture._at_temperature(10_100.0):
+        assert oxygen_mixture.T == 10_100.0
+        assert oxygen_mixture._equilibrium_state() is not original_state
+        assert oxygen_mixture._transport_workspace() is not original_workspace
+
+    assert oxygen_mixture.T == 10_000.0
+    assert oxygen_mixture._equilibrium_state() is original_state
+    assert oxygen_mixture._transport_workspace() is original_workspace


### PR DESCRIPTION
## Summary

- consolidate equilibrium-derived quantities into one reusable immutable state
- share Devoto matrix factorizations and transport intermediates across property calculations
- centralize monatomic electronic moments
- preserve complete cached state across temporary temperature excursions
- compile collision-fit and collision-pair evaluation into the selected Numba kernel
- explicitly invalidate cached equilibrium and transport state when temperature, pressure, feed composition, or any GFE solver control changes

This is PR 2 in the productionization stack and is based on #101. It intentionally excludes analytical temperature derivatives, the log-space equilibrium solver, reduced-equilibrium research code, and JAX.

## Validation

- uv run pytest tests -q: 118 passed
- uv run mypy src
- pre-commit passes on every changed file
- five-run tutorial-10 Si-C-O transport sweep has an identical checksum to #101
- corrected-base median: 2.23 s
- this branch median: 1.24 s
- warm-sweep speedup: 1.80x