### PR TITLE
Differentiate equilibrium temperature properties analytically

### DIFF
--- a/bench/ANALYTIC_HEAT_CAPACITY_2026-08-26.md
+++ b/bench/ANALYTIC_HEAT_CAPACITY_2026-08-26.md
@@ -84,6 +84,31 @@ For 20 temperatures and three SiCO ratios, with seven alternating repetitions:
 The analytical implementation is **2.68x faster**. It also ignores the legacy
 `rel_delta_T` argument, which is retained for API compatibility.
 
+## Connection to the log formulation
+
+The same explicit temperature residual has also been added to the exploratory
+log system. Solving its already-available Jacobian for `du/dT`, where
+`u = log(N)`, reproduces the production analytical mole-fraction tangent and
+heat capacity to `2e-8` relative tolerance at 12000 K.
+
+More importantly, at 10.1325 MPa and 1000 K the production equilibrium reaches
+`log(0)` before a heat capacity can be formed. Log equilibrium converges to a
+`3.5e-11` residual and returns a finite positive heat capacity of
+`950.492919 J/(kg K)`. At 1013.25 Pa and 23000 K, where production warns of
+non-convergence, log equilibrium returns `22364.133435 J/(kg K)`.
+
+This separates the two improvements cleanly: the analytical chain rule removes
+temperature-difference noise, while log variables prevent the underlying
+equilibrium solve from generating zeros or invalid tangents.
+
+## Thermal conductivity check
+
+Thermal conductivity already uses the analytical equilibrium tangent on this
+branch. Across a 0.1 K grid around the known 20862 K Si+ cutoff, changing the
+legacy `rel_delta_T` argument from `0.1` to `1e-8` changes the result bit for
+bit. Every value is finite; the largest local kink is
+`5.6e-6 W/(m K)`. A regression test now fixes this step independence.
+
 ## Remaining discontinuity
 
 This removes numerical derivative excursions, but it cannot make the hard

--- a/bench/ANALYTIC_HEAT_CAPACITY_2026-08-26.md
+++ b/bench/ANALYTIC_HEAT_CAPACITY_2026-08-26.md
@@ -2,7 +2,7 @@
 
 This experiment addresses temperature-derivative outliers in heat capacity
 and thermal conductivity. It builds on the piecewise analytical equilibrium
-tangent introduced earlier on `feature/consolidate-computation-state`.
+tangent introduced earlier in the productionization stack.
 
 ## Root cause
 
@@ -84,22 +84,14 @@ For 20 temperatures and three SiCO ratios, with seven alternating repetitions:
 The analytical implementation is **2.68x faster**. It also ignores the legacy
 `rel_delta_T` argument, which is retained for API compatibility.
 
-## Connection to the log formulation
+## Relationship to the planned log formulation
 
-The same explicit temperature residual has also been added to the exploratory
-log system. Solving its already-available Jacobian for `du/dT`, where
-`u = log(N)`, reproduces the production analytical mole-fraction tangent and
-heat capacity to `2e-8` relative tolerance at 12000 K.
-
-More importantly, at 10.1325 MPa and 1000 K the production equilibrium reaches
-`log(0)` before a heat capacity can be formed. Log equilibrium converges to a
-`3.5e-11` residual and returns a finite positive heat capacity of
-`950.492919 J/(kg K)`. At 1013.25 Pa and 23000 K, where production warns of
-non-convergence, log equilibrium returns `22364.133435 J/(kg K)`.
-
-This separates the two improvements cleanly: the analytical chain rule removes
-temperature-difference noise, while log variables prevent the underlying
-equilibrium solve from generating zeros or invalid tangents.
+The derivative algebra is independent of the equilibrium variables. A later
+stacked change can reuse the same explicit temperature residual with the log
+system's Jacobian to solve for `du/dT`, where `u = log(N)`. Keeping that
+integration separate makes the two effects reviewable: this change removes
+temperature-difference noise, while log variables are intended to improve the
+robustness of the underlying equilibrium solve.
 
 ## Thermal conductivity check
 

--- a/bench/ANALYTIC_HEAT_CAPACITY_2026-08-26.md
+++ b/bench/ANALYTIC_HEAT_CAPACITY_2026-08-26.md
@@ -1,0 +1,93 @@
+# Analytical equilibrium heat capacity
+
+This experiment addresses temperature-derivative outliers in heat capacity
+and thermal conductivity. It builds on the piecewise analytical equilibrium
+tangent introduced earlier on `feature/consolidate-computation-state`.
+
+## Root cause
+
+Thermal conductivity already consumes the analytical mole-fraction derivative
+on this branch. Heat capacity was the remaining property that changed the
+mixture temperature to `T(1 +/- 0.001)`, performed two independent equilibrium
+solves, and differenced their enthalpies.
+
+That calculation has three distinct error sources:
+
+1. ordinary second-order truncation error;
+1. convergence or branch differences between the two equilibrium solves;
+1. a finite-difference interval straddling a hard electronic-level cutoff,
+   which turns a discrete partition-function change into a step-dependent
+   local spike.
+
+The third effect is inherent to differencing a discontinuous model. Reducing
+the temperature step narrows and increases such an excursion rather than
+providing a globally convergent derivative.
+
+## Formulation
+
+For the enthalpy per unit mass written in mole fractions as
+
+```text
+H = sum_i(x_i A_i) / sum_i(x_i m_i),
+```
+
+the implementation applies the quotient rule using the implicit equilibrium
+`dx/dT`. Here `A_i` contains species internal energy, reference energy, the
+`k_B T` pressure term, and the existing zero-temperature reference shift.
+
+The full reference-energy tangent includes both explicit temperature
+dependence and the composition-dependent ionisation lowering:
+
+```text
+dE0/dT = partial(E0)/partial(T) + partial(E0)/partial(N) @ dN/dT.
+```
+
+Species internal-energy derivatives are analytical. Monatomic electronic heat
+capacity is the fixed-active-set energy variance divided by `k_B T^2`;
+diatomic and polyatomic vibrational terms use stable hyperbolic-function
+forms. The result is piecewise analytical: the active electronic levels and
+the minimum-reference-energy species remain fixed at a discrete crossing.
+
+## Verification
+
+At 10000 K and atmospheric pressure:
+
+| Mixture | Analytical Cp | Error of old `1e-3` difference | Error at `1e-5` |
+|---|---:|---:|---:|
+| Oxygen | 3248.946038 | +0.012634 | +0.0000013 |
+| SiCO | 5504.183153 | +0.010732 | +0.0000013 |
+
+The shrinking-step result converges quadratically to the analytical value.
+Species energy derivatives independently agree with central differences to a
+relative tolerance of `2e-8` from 1000 to 25000 K.
+
+A 25 K SiCO scan found a maximum `43.5 J/(kg K)` change in the old result when
+its relative step was changed from `1e-3` to `3e-4`. The largest discrepancies
+occur in paired points around electronic cutoffs. The analytical result stays
+finite and follows the local branch without averaging across the jump.
+
+## Performance
+
+Command:
+
+```console
+PYTHONPATH=src:. .venv/bin/python bench/bench_heat_capacity_derivative.py
+```
+
+For 20 temperatures and three SiCO ratios, with seven alternating repetitions:
+
+| Method | Median |
+|---|---:|
+| Two-solve finite difference | 1.005774 s |
+| Analytical equilibrium tangent | 0.375863 s |
+
+The analytical implementation is **2.68x faster**. It also ignores the legacy
+`rel_delta_T` argument, which is retained for API compatibility.
+
+## Remaining discontinuity
+
+This removes numerical derivative excursions, but it cannot make the hard
+electronic cutoff itself differentiable. At a level crossing the model still
+has distinct one-sided values. The local Gibbs branch selection explored by
+the log solver, or a physically justified mollified occupation model, remains
+the route to defining behaviour exactly at those crossings.

--- a/bench/bench_heat_capacity_derivative.py
+++ b/bench/bench_heat_capacity_derivative.py
@@ -1,0 +1,67 @@
+"""Benchmark analytical heat capacity against the former finite difference."""
+
+from __future__ import annotations
+
+import statistics
+import time
+
+import numpy as np
+
+from bench.workloads import make_sico
+
+TEMPERATURES = np.linspace(1000.0, 25000.0, 20)
+MIXTURES = (0.1, 0.5, 0.9)
+
+
+def finite_difference_heat_capacity(mixture, relative_step=0.001):
+    """Reproduce the heat-capacity implementation before this experiment."""
+    temperature = mixture.T
+    with mixture._at_temperature(temperature * (1 - relative_step)):
+        enthalpy_low = mixture.calculate_enthalpy()
+    with mixture._at_temperature(temperature * (1 + relative_step)):
+        enthalpy_high = mixture.calculate_enthalpy()
+    return (enthalpy_high - enthalpy_low) / (2 * relative_step * temperature)
+
+
+def sweep(method):
+    """Run a tutorial-style SiCO heat-capacity sweep."""
+    values = []
+    for fraction in MIXTURES:
+        mixture = make_sico(fraction)
+        for temperature in TEMPERATURES:
+            mixture.T = float(temperature)
+            values.append(method(mixture))
+    return np.asarray(values)
+
+
+def main():
+    """Report alternating timings and the finite-difference discrepancy."""
+    methods = {
+        "finite difference": finite_difference_heat_capacity,
+        "analytical": lambda mixture: mixture.calculate_heat_capacity(),
+    }
+    for method in methods.values():
+        sweep(method)
+
+    samples = {label: [] for label in methods}
+    results = {}
+    for label, method in list(methods.items()) * 7:
+        start = time.perf_counter()
+        results[label] = sweep(method)
+        samples[label].append(time.perf_counter() - start)
+
+    medians = {
+        label: statistics.median(values) for label, values in samples.items()
+    }
+    for label in methods:
+        print(f"{label:<18} median={medians[label]:.6f} s {samples[label]}")
+    print(
+        "speedup            "
+        f"{medians['finite difference'] / medians['analytical']:.3f}x"
+    )
+    difference = np.abs(results["finite difference"] - results["analytical"])
+    print(f"maximum difference {difference.max():.6e} J/(kg K)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/minplascalc/functions_transport.py
+++ b/src/minplascalc/functions_transport.py
@@ -3375,8 +3375,9 @@ def thermal_conductivity(
 
     Thermal conductivity, calculation per [Devoto1966]_ (eq. 2, 13 and 18).
     Fourth-order approximation.
-    Numerical derivative performed to obtain :math:`\frac{dx_i}{dT}` for
-    :math:`\vec{\nabla} x` in the :math:`\vec{d_i}` expression.
+    A piecewise analytical equilibrium derivative provides
+    :math:`\frac{dx_i}{dT}` for :math:`\vec{\nabla} x` in the
+    :math:`\vec{d_i}` expression.
 
     It assumes that there is no pressure gradient and no external forces.
 
@@ -3385,7 +3386,8 @@ def thermal_conductivity(
     mixture : LTE
         Mixture of species.
     rel_delta_T : float
-        Relative delta T for numerical derivative.
+        Retained for API compatibility; the analytical derivative does not
+        use a temperature step.
     DTterms_yn : bool
         Flag to include thermal diffusion terms.
     ni_limit : float
@@ -3524,16 +3526,10 @@ def thermal_conductivity(
 
     ### reactional tk components - normal diffusion term ###
 
-    # Compute the derivative of the number densities with respect to
-    # temperature. x is the concentration of species i, x = ni / ntot
+    # Compute the equilibrium mole-fraction derivative at the current active
+    # electronic-level set. x is the concentration x_i = n_i / n_tot.
     Tval = mixture.T
-    with mixture._at_temperature(Tval * (1 + rel_delta_T)):
-        n_positive = mixture.calculate_composition()
-    with mixture._at_temperature(Tval * (1 - rel_delta_T)):
-        n_negative = mixture.calculate_composition()
-    x_positive = n_positive / np.sum(n_positive)
-    x_negative = n_negative / np.sum(n_negative)
-    dxdT = (x_positive - x_negative) / (2 * rel_delta_T * mixture.T)
+    dxdT = mixture.calculate_composition_temperature_derivative()
 
     locDij = q_system.diffusion_matrix()
 

--- a/src/minplascalc/mixture.py
+++ b/src/minplascalc/mixture.py
@@ -275,6 +275,22 @@ class LTE:
             A_matrix[j, -1] = qc
             A_matrix_transpose[-1, j] = qc
 
+    def _constraint_matrix(self) -> np.ndarray:
+        """Return species-by-conservation-law coefficients."""
+        element_names = sorted(
+            {element for sp in self.species for element in sp.stoichiometry}
+        )
+        _, constraint_count = self._get_constraint_dimensions(
+            len(element_names)
+        )
+        matrix = np.zeros((len(self.species), constraint_count))
+        for column, element in enumerate(element_names):
+            matrix[:, column] = [
+                sp.stoichiometry.get(element, 0) for sp in self.species
+            ]
+        self._setup_charge_constraints(matrix, matrix.T)
+        return matrix
+
     def _calculate_ionization_lowering(
         self, number_densities: np.ndarray
     ) -> np.ndarray:
@@ -313,6 +329,64 @@ class LTE:
                 )
 
         return dE
+
+    def _ionization_lowering_derivatives(
+        self, particle_numbers: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return ionisation-lowering derivatives for the active species."""
+        count = len(self.species)
+        dE_dN = np.zeros((count, count))
+        dE_dT = np.zeros(count)
+        charges = self.charge_numbers
+        positive = charges > 0
+
+        charge_sum = particle_numbers[positive] @ charges[positive]
+        charge_square_sum = particle_numbers[positive] @ charges[positive] ** 2
+        z_star = charge_square_sum / charge_sum
+        denominator = z_star + 1
+
+        dzstar_dN = np.zeros(count)
+        dzstar_dN[positive] = (
+            charges[positive] ** 2 * charge_sum
+            - charge_square_sum * charges[positive]
+        ) / charge_sum**2
+
+        total_particles = particle_numbers.sum()
+        electron_index = count - 1
+        electron_particles = particle_numbers[electron_index]
+        volume = total_particles * u.k_b * self.T / self.P
+        electron_density = electron_particles / volume
+        debye_pow3 = (
+            u.epsilon_0
+            * u.k_b
+            * self.T
+            / (4 * np.pi * denominator * electron_density * u.e**2)
+        ) ** (3 / 2)
+
+        dlog_ratio_dN = 1.5 * dzstar_dN / denominator - 0.5 / total_particles
+        dlog_ratio_dN[electron_index] += 0.5 / electron_particles
+
+        for i, charge in enumerate(charges):
+            if charge <= 0:
+                continue
+            ion_sphere_pow3 = 3 * charge / (4 * np.pi * electron_density)
+            ratio = ion_sphere_pow3 / debye_pow3
+            shape = (ratio + 1) ** (2 / 3) - 1
+            shape_derivative = 2 / 3 * (ratio + 1) ** (-1 / 3)
+            prefactor = u.k_b * self.T / 2
+
+            ratio_dN = ratio * dlog_ratio_dN
+            dE_dN[i] = prefactor * (
+                shape_derivative * ratio_dN / denominator
+                - shape * dzstar_dN / denominator**2
+            )
+            dE_dT[i] = (
+                u.k_b
+                / (2 * denominator)
+                * (shape - 2 * ratio * shape_derivative)
+            )
+
+        return dE_dN, dE_dT
 
     def _get_species_for_iteration(
         self, number_densities: np.ndarray
@@ -473,6 +547,44 @@ class LTE:
         # Return the reference energy and ionisation energy lowering.
         return E0, dE
 
+    def __get_reference_energy_derivatives(
+        self,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return derivatives of reference energies with respect to N and T."""
+        dE_dN, dE_dT = self._ionization_lowering_derivatives(self.__Ni)
+        E0_dN = np.zeros_like(dE_dN)
+        E0_dT = np.zeros_like(dE_dT)
+
+        neutral_species = [sp for sp in self.species if sp.charge_number == 0]
+        for neutral_sp in neutral_species:
+            negative = sorted(
+                (
+                    (i, sp)
+                    for i, sp in enumerate(self.species)
+                    if sp.stoichiometry == neutral_sp.stoichiometry
+                    and sp.charge_number <= 0
+                ),
+                key=lambda item: item[1].charge_number,
+                reverse=True,
+            )
+            positive = sorted(
+                (
+                    (i, sp)
+                    for i, sp in enumerate(self.species)
+                    if sp.stoichiometry == neutral_sp.stoichiometry
+                    and sp.charge_number >= 0
+                ),
+                key=lambda item: item[1].charge_number,
+            )
+            for (source, _), (target, _) in zip(positive[:-1], positive[1:]):
+                E0_dN[target] = E0_dN[source] - dE_dN[source]
+                E0_dT[target] = E0_dT[source] - dE_dT[source]
+            for (source, _), (target, _) in zip(negative[:-1], negative[1:]):
+                E0_dN[target] = E0_dN[source] + dE_dN[target]
+                E0_dT[target] = E0_dT[source] + dE_dT[target]
+
+        return E0_dN, E0_dT
+
     def calculate_composition(self) -> np.ndarray:
         r"""Calculate the LTE composition of the plasma in m^-3.
 
@@ -615,23 +727,12 @@ class LTE:
         # The first nb_species rows and columns are for the species.
         # The next len(self._elements) rows and columns are for the elements.
         # The last row and column are for the charge neutrality.
-        A_matrix_constraints = np.zeros((len(self.species), constraints_dof))
-        A_matrix_constraints_transpose = np.zeros(
-            (constraints_dof, len(self.species))
-        )
+        A_matrix_constraints = self._constraint_matrix()
+        A_matrix_constraints_transpose = A_matrix_constraints.T
         b_vector_constraints = np.zeros(constraints_dof)
 
         for i, element in enumerate(elements):
-            stoichiometric_coefficients = element["stoich_coeff"]
-            assert isinstance(stoichiometric_coefficients, list)
-            for j, sc in enumerate(stoichiometric_coefficients):
-                A_matrix_constraints[j, i] = sc
-                A_matrix_constraints_transpose[i, j] = sc
             b_vector_constraints[i] = element["N_tot"]
-
-        self._setup_charge_constraints(
-            A_matrix_constraints, A_matrix_constraints_transpose
-        )
 
         gfe_matrix[:nb_species, nb_species:] = A_matrix_constraints
         gfe_matrix[nb_species:, :nb_species] = A_matrix_constraints_transpose
@@ -750,6 +851,67 @@ class LTE:
         N_tot = N_i.sum()  # Total number of particles in the plasma.
         V = N_tot * kbt / self.P  # Volume of the plasma, in m3.
         return N_i / V  # Number density of each species, in particles/m3.
+
+    def calculate_composition_temperature_derivative(self) -> np.ndarray:
+        r"""Calculate the piecewise analytical derivative of mole fractions.
+
+        The equilibrium conditions are differentiated implicitly at the
+        converged state. Electronic levels below the ionisation-lowered cutoff
+        retain their current active/inactive status, so the result is the
+        one-sided analytical branch between discrete level crossings.
+
+        Returns
+        -------
+        np.ndarray
+            :math:`dx_i/dT`, in :math:`\text{K}^{-1}`.
+        """
+        self.calculate_composition()
+        particle_numbers = self.__Ni
+        particle_total = particle_numbers.sum()
+        count = len(self.species)
+        kbt = u.k_b * self.T
+        volume = particle_total * kbt / self.P
+
+        _, lowering = self.__get_reference_energies()
+        reference_dN, reference_dT = self.__get_reference_energy_derivatives()
+        partitions = np.array(
+            [
+                species.total_partition_function(volume, self.T, dE)
+                for species, dE in zip(self.species, lowering)
+            ]
+        )
+        log_partition_ratio = np.log(partitions / particle_numbers)
+        dlog_partition_dT = np.array(
+            [
+                1 / self.T + species.dlog_total_partition_dT(self.T, dE)
+                for species, dE in zip(self.species, lowering)
+            ]
+        )
+        chemical_potential_dT = (
+            reference_dT
+            - u.k_b * log_partition_ratio
+            - kbt * dlog_partition_dT
+        )
+
+        constraints = self._constraint_matrix()
+        constraint_count = constraints.shape[1]
+        system = np.zeros((count + constraint_count,) * 2)
+        system[:count, :count] = (
+            -kbt / particle_total
+            + np.diag(kbt / particle_numbers)
+            + reference_dN
+        )
+        system[:count, count:] = constraints
+        system[count:, :count] = constraints.T
+
+        rhs = np.zeros(count + constraint_count)
+        rhs[:count] = -chemical_potential_dT
+        particle_derivative = np.linalg.solve(system, rhs)[:count]
+        total_derivative = particle_derivative.sum()
+        return (
+            particle_derivative / particle_total
+            - particle_numbers * total_derivative / particle_total**2
+        )
 
     def _equilibrium_state(self) -> _EquilibriumState:
         """Return all commonly used quantities for the current LTE state."""
@@ -1145,6 +1307,13 @@ class LTEWithoutElectrons(LTE):
         """Calculate ionization energy lowering (no electrons case)."""
         nb_species = len(self.species)
         return np.zeros(nb_species)  # No ionization lowering without electrons
+
+    def _ionization_lowering_derivatives(
+        self, particle_numbers: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return zero lowering derivatives for electron-free mixtures."""
+        count = len(self.species)
+        return np.zeros((count, count)), np.zeros(count)
 
     def _get_species_for_iteration(
         self, number_densities: np.ndarray

--- a/src/minplascalc/mixture.py
+++ b/src/minplascalc/mixture.py
@@ -1160,20 +1160,16 @@ class LTE:
     def calculate_heat_capacity(self, rel_delta_T: float = 0.001) -> float:
         r"""Calculate the LTE heat capacity at constant pressure of the plasma.
 
-        Calculate the LTE heat capacity at constant pressure of the plasma
-        based on current conditions and species composition.
-
-        This is done by performing multiple LTE composition recalculations and
-        can be time-consuming to execute - when performing large quantities of
-        Cp calculations at different temperatures, it is more efficient to
-        calculate enthalpies and perform a numerical derivative external to
-        minplascalc.
+        The equilibrium enthalpy is differentiated analytically along the
+        constrained composition tangent. The electronic-level active set and
+        the species with the lowest reference energy are held fixed, making
+        this a piecewise derivative between discrete model transitions.
 
         Parameters
         ----------
         rel_delta_T : float, optional
-            Relative change in temperature to calculate the numerical
-            derivative, by default 0.001.
+            Retained for API compatibility; the analytical derivative does not
+            use a temperature step.
 
         Returns
         -------
@@ -1187,22 +1183,66 @@ class LTE:
         .. math::
 
             C_p = \frac{dH}{dT}
-                \approx \frac{H(T + \Delta T) - H(T - \Delta T)}{2 \Delta T}
 
         where:
 
         * :math:`C_p` is the heat capacity at constant pressure,
           in :math:`\text{J.kg}^{-1}.\text{K}^{-1}`,
         * :math:`H` is the enthalpy of the plasma, in :math:`\text{J.kg}^{-1}`,
-        * :math:`T` is the temperature, in :math:`\text{K}`, and
-        * :math:`\Delta T` is the relative change in temperature.
+        * :math:`T` is the temperature, in :math:`\text{K}`.
         """
-        start_temperature = self.T
-        with self._at_temperature(start_temperature * (1 - rel_delta_T)):
-            enthalpy_low = self.calculate_enthalpy()
-        with self._at_temperature(start_temperature * (1 + rel_delta_T)):
-            enthalpy_high = self.calculate_enthalpy()
-        return (enthalpy_high - enthalpy_low) / (2 * rel_delta_T * self.T)
+        del rel_delta_T
+        state = self._equilibrium_state()
+        tangent = self._equilibrium_temperature_tangent()
+        internal_energies = np.array(
+            [
+                species.internal_energy(state.T, lowering)
+                for species, lowering in zip(
+                    self.species, state.ionization_lowering
+                )
+            ]
+        )
+        internal_energy_derivatives = np.array(
+            [
+                species.dinternal_energy_dT(state.T, lowering)
+                for species, lowering in zip(
+                    self.species, state.ionization_lowering
+                )
+            ]
+        )
+        particle_enthalpies = (
+            internal_energies + state.reference_energies + state.kbt
+        )
+        particle_enthalpy_derivatives = (
+            internal_energy_derivatives
+            + tangent.reference_energy_derivative
+            + u.k_b
+        )
+
+        minimum = int(np.argmin(state.reference_energies))
+        mass_ratios = state.masses / state.masses[minimum]
+        relative_enthalpies = (
+            particle_enthalpies
+            - state.reference_energies[minimum] * mass_ratios
+        )
+        relative_enthalpy_derivatives = (
+            particle_enthalpy_derivatives
+            - tangent.reference_energy_derivative[minimum] * mass_ratios
+        )
+
+        mole_fractions = state.mole_fractions
+        mole_fraction_derivative = tangent.mole_fraction_derivative
+        mean_mass = mole_fractions @ state.masses
+        mean_mass_derivative = mole_fraction_derivative @ state.masses
+        enthalpy_per_particle = mole_fractions @ relative_enthalpies
+        enthalpy_derivative = (
+            mole_fraction_derivative @ relative_enthalpies
+            + mole_fractions @ relative_enthalpy_derivatives
+        )
+        return (
+            enthalpy_derivative * mean_mass
+            - enthalpy_per_particle * mean_mass_derivative
+        ) / mean_mass**2
 
     def calculate_viscosity(self) -> float:
         r"""Calculate the LTE viscosity of the plasma in :math:`\text{Pa.s}`.

--- a/src/minplascalc/mixture.py
+++ b/src/minplascalc/mixture.py
@@ -38,6 +38,15 @@ class _EquilibriumState:
     mean_particle_mass: float
 
 
+@dataclass(frozen=True)
+class _EquilibriumTemperatureTangent:
+    """Piecewise derivative of the constrained equilibrium state."""
+
+    particle_derivative: np.ndarray
+    mole_fraction_derivative: np.ndarray
+    reference_energy_derivative: np.ndarray
+
+
 class LTE:
     def __init__(
         self,
@@ -852,19 +861,10 @@ class LTE:
         V = N_tot * kbt / self.P  # Volume of the plasma, in m3.
         return N_i / V  # Number density of each species, in particles/m3.
 
-    def calculate_composition_temperature_derivative(self) -> np.ndarray:
-        r"""Calculate the piecewise analytical derivative of mole fractions.
-
-        The equilibrium conditions are differentiated implicitly at the
-        converged state. Electronic levels below the ionisation-lowered cutoff
-        retain their current active/inactive status, so the result is the
-        one-sided analytical branch between discrete level crossings.
-
-        Returns
-        -------
-        np.ndarray
-            :math:`dx_i/dT`, in :math:`\text{K}^{-1}`.
-        """
+    def _equilibrium_temperature_tangent(
+        self,
+    ) -> _EquilibriumTemperatureTangent:
+        """Differentiate the full constrained equilibrium state."""
         self.calculate_composition()
         particle_numbers = self.__Ni
         particle_total = particle_numbers.sum()
@@ -908,10 +908,33 @@ class LTE:
         rhs[:count] = -chemical_potential_dT
         particle_derivative = np.linalg.solve(system, rhs)[:count]
         total_derivative = particle_derivative.sum()
-        return (
+        mole_fraction_derivative = (
             particle_derivative / particle_total
             - particle_numbers * total_derivative / particle_total**2
         )
+        reference_energy_derivative = (
+            reference_dT + reference_dN @ particle_derivative
+        )
+        return _EquilibriumTemperatureTangent(
+            particle_derivative=particle_derivative,
+            mole_fraction_derivative=mole_fraction_derivative,
+            reference_energy_derivative=reference_energy_derivative,
+        )
+
+    def calculate_composition_temperature_derivative(self) -> np.ndarray:
+        r"""Calculate the piecewise analytical derivative of mole fractions.
+
+        The equilibrium conditions are differentiated implicitly at the
+        converged state. Electronic levels below the ionisation-lowered cutoff
+        retain their current active/inactive status, so the result is the
+        one-sided analytical branch between discrete level crossings.
+
+        Returns
+        -------
+        np.ndarray
+            :math:`dx_i/dT`, in :math:`\text{K}^{-1}`.
+        """
+        return self._equilibrium_temperature_tangent().mole_fraction_derivative
 
     def _equilibrium_state(self) -> _EquilibriumState:
         """Return all commonly used quantities for the current LTE state."""

--- a/src/minplascalc/mixture.py
+++ b/src/minplascalc/mixture.py
@@ -1208,8 +1208,8 @@ class LTE:
         Parameters
         ----------
         rel_delta_T : float, optional
-            TODO:Relative change in temperature to calculate the numerical
-            derivative, by default 0.001.
+            Retained for API compatibility; the piecewise analytical
+            composition derivative does not use a temperature increment.
         DTterms_yn : bool, optional
             TODO:Flag to include the temperature-dependent terms in the
             calculation, by default True.

--- a/src/minplascalc/species.py
+++ b/src/minplascalc/species.py
@@ -121,6 +121,10 @@ class BaseSpecies:
     def internal_energy(self, T, dE):
         raise NotImplementedError
 
+    def dinternal_energy_dT(self, T, dE):
+        """Return the fixed-active-set temperature derivative of energy."""
+        raise NotImplementedError
+
 
 class Species(BaseSpecies):
     def __init__(
@@ -335,14 +339,18 @@ class Monatomic(Species):
             f"Emission lines: {len(self.emission_lines)}"
         )
 
-    def _electronic_moments(self, T: float, dE: float) -> tuple[float, float]:
-        """Electronic partition sum and its energy-weighted first moment."""
+    def _electronic_moments(
+        self, T: float, dE: float
+    ) -> tuple[float, float, float]:
+        """Electronic partition sum and first two energy moments."""
         beta = 1 / (u.k_b * T)
         below = self._level_energies < (self.ionisation_energy - dE)
         weights = self._degeneracies * below
         boltzmann = np.exp(-beta * self._level_energies)
-        return float(weights @ boltzmann), float(
-            (weights * self._level_energies) @ boltzmann
+        return (
+            float(weights @ boltzmann),
+            float((weights * self._level_energies) @ boltzmann),
+            float((weights * self._level_energies**2) @ boltzmann),
         )
 
     def internal_partition_function(self, T: float, dE: float) -> float:
@@ -387,7 +395,7 @@ class Monatomic(Species):
 
             g_i = 2J_i + 1
         """
-        partition, _ = self._electronic_moments(T, dE)
+        partition, _, _ = self._electronic_moments(T, dE)
         return partition
 
     def internal_energy(self, T: float, dE: float) -> float:
@@ -438,9 +446,18 @@ class Monatomic(Species):
         # Calculate the translational energy.
         translational_energy = 3 / 2 * u.k_b * T
 
-        partition, energy_moment = self._electronic_moments(T, dE)
+        partition, energy_moment, _ = self._electronic_moments(T, dE)
         electronic_energy = energy_moment / partition
         return translational_energy + electronic_energy
+
+    def dinternal_energy_dT(self, T: float, dE: float) -> float:
+        """Return piecewise analytical monatomic heat capacity per particle."""
+        partition, first_moment, second_moment = self._electronic_moments(
+            T, dE
+        )
+        mean = first_moment / partition
+        variance = second_moment / partition - mean**2
+        return 1.5 * u.k_b + variance / (u.k_b * T**2)
 
 
 class Diatomic(Species):
@@ -738,6 +755,12 @@ class Diatomic(Species):
             + rotational_energy
             + vibrational_energy
         )
+
+    def dinternal_energy_dT(self, T: float, dE: float) -> float:
+        """Return analytical diatomic heat capacity per particle."""
+        ratio = self.w_e / (2 * u.k_b * T)
+        inverse_sinh = 2 * np.exp(-ratio) / (-np.expm1(-2 * ratio))
+        return 2.5 * u.k_b + u.k_b * (ratio * inverse_sinh) ** 2
 
 
 class Polyatomic(Species):
@@ -1066,6 +1089,15 @@ class Polyatomic(Species):
             + vibrational_energy
         )
 
+    def dinternal_energy_dT(self, T: float, dE: float) -> float:
+        """Return analytical polyatomic heat capacity per particle."""
+        ratios = np.asarray(self.wi_e) / (2 * u.k_b * T)
+        inverse_sinh = 2 * np.exp(-ratios) / (-np.expm1(-2 * ratios))
+        rotational = 1.0 if self.linear_yn else 1.5
+        return u.k_b * (
+            1.5 + rotational + np.sum((ratios * inverse_sinh) ** 2)
+        )
+
 
 class Electron(BaseSpecies):
     def __init__(self):
@@ -1162,6 +1194,10 @@ class Electron(BaseSpecies):
         electronic_energy = 0.0
         # Return the total internal energy.
         return translational_energy + electronic_energy
+
+    def dinternal_energy_dT(self, T: float, dE: float) -> float:
+        """Return electron heat capacity per particle."""
+        return 1.5 * u.k_b
 
 
 def from_file(datafile: str | Path) -> Monatomic | Diatomic | Polyatomic:

--- a/src/minplascalc/species.py
+++ b/src/minplascalc/species.py
@@ -66,6 +66,29 @@ class BaseSpecies:
             * self.internal_partition_function(T, dE)
         )
 
+    def dlog_total_partition_dT(self, T: float, dE: float) -> float:
+        r"""Temperature derivative of ``log(Z)`` at fixed volume.
+
+        This is the canonical identity
+        :math:`\partial_T \log Z = U / (k_B T^2)`. For monatomic species,
+        the ionisation-lowered electronic-level active set is held fixed, so
+        the derivative is piecewise analytical at level crossings.
+
+        Parameters
+        ----------
+        T : float
+            Temperature, in :math:`\text{K}`.
+        dE : float
+            Ionisation energy lowering, in :math:`\text{J}`.
+
+        Returns
+        -------
+        float
+            Logarithmic partition-function derivative, in
+            :math:`\text{K}^{-1}`.
+        """
+        return self.internal_energy(T, dE) / (u.k_b * T**2)
+
     def translational_partition_function(self, T: float) -> float:
         r"""Calculate the volumic translational partition function.
 

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import minplascalc as mpc
@@ -46,6 +47,61 @@ LOW_P, MID_P, HIGH_P = 10132.5, 101325, 1013250
 LOW_X0 = [0, 0, 0, 0, 0, 0.1, 0, 0, 0, 0, 0.9, 0, 0, 0, 0]
 MID_X0 = [0, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0]
 HIGH_X0 = [0, 0, 0, 0, 0, 0.9, 0, 0, 0, 0, 0.1, 0, 0, 0, 0]
+
+
+@pytest.mark.parametrize(
+    "fixture_name,T",
+    [
+        ("mixture_simple", 2000.0),
+        ("mixture_simple", 12000.0),
+        ("mixture_simple", 25000.0),
+        ("mixture_complex", 2000.0),
+        ("mixture_complex", 12000.0),
+        ("mixture_complex", 25000.0),
+    ],
+)
+def test_piecewise_composition_temperature_derivative(
+    request, fixture_name, T
+):
+    mixture = request.getfixturevalue(fixture_name)
+    mixture.T = T
+    mixture.calculate_composition()
+    analytical = mixture.calculate_composition_temperature_derivative()
+
+    relative_step = 0.001
+    with mixture._at_temperature(T * (1 + relative_step)):
+        high = mixture.calculate_composition()
+        high /= high.sum()
+    with mixture._at_temperature(T * (1 - relative_step)):
+        low = mixture.calculate_composition()
+        low /= low.sum()
+    finite_difference = (high - low) / (2 * relative_step * T)
+
+    scaled_error = np.linalg.norm(T * (analytical - finite_difference))
+    scaled_reference = np.linalg.norm(T * finite_difference)
+    assert scaled_error <= 3e-4 * scaled_reference + 1e-9
+    assert analytical.sum() == pytest.approx(0.0, abs=1e-18)
+
+
+def test_electron_free_composition_temperature_derivative():
+    mixture = mpc.mixture.lte_from_names(
+        ["O2", "O"],
+        x0=[1, 0],
+        T=12000.0,
+        P=101325.0,
+        electrons_yn=False,
+    )
+    analytical = mixture.calculate_composition_temperature_derivative()
+    relative_step = 0.001
+    with mixture._at_temperature(mixture.T * (1 + relative_step)):
+        high = mixture.calculate_composition()
+        high /= high.sum()
+    with mixture._at_temperature(mixture.T * (1 - relative_step)):
+        low = mixture.calculate_composition()
+        low /= low.sum()
+    finite_difference = (high - low) / (2 * relative_step * mixture.T)
+
+    assert analytical == pytest.approx(finite_difference, rel=2e-5)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -212,11 +212,11 @@ def test_viscosity_complex(mixture_complex, x0, result, tol):
 @pytest.mark.parametrize(
     "T, P, result, tol",
     [
-        (MID_T, MID_P, 1.685060072421295, 1e-5),
-        (LOW_T, LOW_P, 0.051617047810062884, 1e-7),
-        (HIGH_T, LOW_P, 4.464230656329954, 1e-5),
-        (LOW_T, HIGH_P, 0.05161701653201179, 1e-7),
-        (HIGH_T, HIGH_P, 6.620636394638989, 1e-5),
+        (MID_T, MID_P, 1.6059372309662145, 1e-5),
+        (LOW_T, LOW_P, 0.052125335668461684, 1e-7),
+        (HIGH_T, LOW_P, 5.469166699613663, 1e-5),
+        (LOW_T, HIGH_P, 0.05212530435312864, 1e-7),
+        (HIGH_T, HIGH_P, 8.046667069994843, 1e-5),
     ],
 )
 def test_thermal_conductivity_simple(mixture_simple, T, P, result, tol):
@@ -231,9 +231,9 @@ def test_thermal_conductivity_simple(mixture_simple, T, P, result, tol):
 @pytest.mark.parametrize(
     "x0, result, tol",
     [
-        (LOW_X0, 1.9640277033345197, 1e-5),
-        (MID_X0, 2.1889980105505384, 1e-5),
-        (HIGH_X0, 2.383560087502664, 1e-5),
+        (LOW_X0, 2.054126160699179, 1e-5),
+        (MID_X0, 2.275655690865495, 1e-5),
+        (HIGH_X0, 2.426977891327536, 1e-5),
     ],
 )
 def test_thermal_conductivity_complex(mixture_complex, x0, result, tol):

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -212,11 +212,11 @@ def test_viscosity_complex(mixture_complex, x0, result, tol):
 @pytest.mark.parametrize(
     "T, P, result, tol",
     [
-        (MID_T, MID_P, 1.6059411995888206, 1e-5),
-        (LOW_T, LOW_P, 0.052125335672304166, 1e-7),
-        (HIGH_T, LOW_P, 5.469144033857229, 1e-5),
-        (LOW_T, HIGH_P, 0.0521253043533545, 1e-7),
-        (HIGH_T, HIGH_P, 8.04668554450143, 1e-5),
+        (MID_T, MID_P, 1.685060072421295, 1e-5),
+        (LOW_T, LOW_P, 0.051617047810062884, 1e-7),
+        (HIGH_T, LOW_P, 4.464230656329954, 1e-5),
+        (LOW_T, HIGH_P, 0.05161701653201179, 1e-7),
+        (HIGH_T, HIGH_P, 6.620636394638989, 1e-5),
     ],
 )
 def test_thermal_conductivity_simple(mixture_simple, T, P, result, tol):
@@ -231,9 +231,9 @@ def test_thermal_conductivity_simple(mixture_simple, T, P, result, tol):
 @pytest.mark.parametrize(
     "x0, result, tol",
     [
-        (LOW_X0, 2.054123612714577, 1e-5),
-        (MID_X0, 2.275659141366203, 1e-5),
-        (HIGH_X0, 2.4269824515817566, 1e-5),
+        (LOW_X0, 1.9640277033345197, 1e-5),
+        (MID_X0, 2.1889980105505384, 1e-5),
+        (HIGH_X0, 2.383560087502664, 1e-5),
     ],
 )
 def test_thermal_conductivity_complex(mixture_complex, x0, result, tol):

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -142,11 +142,11 @@ def test_density_complex(mixture_complex, x0, result, tol):
 @pytest.mark.parametrize(
     "T, P, result, tol",
     [
-        (MID_T, MID_P, 3248.959, 1e-2),
+        (MID_T, MID_P, 3248.946, 1e-2),
         (LOW_T, LOW_P, 1081.252, 1e-2),
-        (HIGH_T, LOW_P, 27606.7, 1e-1),
+        (HIGH_T, LOW_P, 27606.856, 1e-1),
         (LOW_T, HIGH_P, 1081.252, 1e-2),
-        (HIGH_T, HIGH_P, 7297.516, 1e-2),
+        (HIGH_T, HIGH_P, 7297.441, 1e-2),
     ],
 )
 def test_heat_capacity_simple(mixture_simple, T, P, result, tol):
@@ -161,9 +161,9 @@ def test_heat_capacity_simple(mixture_simple, T, P, result, tol):
 @pytest.mark.parametrize(
     "x0, result, tol",
     [
-        (LOW_X0, 6027.484, 1e-2),
-        (MID_X0, 5504.194, 1e-2),
-        (HIGH_X0, 6061.864, 1e-2),
+        (LOW_X0, 6027.503, 1e-2),
+        (MID_X0, 5504.183, 1e-2),
+        (HIGH_X0, 6061.862, 1e-2),
     ],
 )
 def test_heat_capacity_complex(mixture_complex, x0, result, tol):
@@ -172,6 +172,26 @@ def test_heat_capacity_complex(mixture_complex, x0, result, tol):
     thisresult = mixture_complex.calculate_heat_capacity()
 
     assert thisresult == pytest.approx(result, abs=tol)
+
+
+@pytest.mark.parametrize("fixture_name", ["mixture_simple", "mixture_complex"])
+def test_heat_capacity_is_analytical_temperature_derivative(
+    request, fixture_name
+):
+    mixture = request.getfixturevalue(fixture_name)
+    mixture.T = 12000.0
+    analytical = mixture.calculate_heat_capacity(rel_delta_T=0.1)
+    assert mixture.calculate_heat_capacity(rel_delta_T=1e-8) == analytical
+
+    relative_step = 1e-5
+    with mixture._at_temperature(mixture.T * (1 - relative_step)):
+        enthalpy_low = mixture.calculate_enthalpy()
+    with mixture._at_temperature(mixture.T * (1 + relative_step)):
+        enthalpy_high = mixture.calculate_enthalpy()
+    finite_difference = (enthalpy_high - enthalpy_low) / (
+        2 * relative_step * mixture.T
+    )
+    assert analytical == pytest.approx(finite_difference, rel=2e-8)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -264,6 +264,20 @@ def test_thermal_conductivity_complex(mixture_complex, x0, result, tol):
     assert thisresult == pytest.approx(result, abs=tol)
 
 
+def test_thermal_conductivity_is_temperature_step_independent(
+    mixture_complex,
+):
+    mixture_complex.T = 20862.0
+    wide_step = mixture_complex.calculate_thermal_conductivity(rel_delta_T=0.1)
+    narrow_step = mixture_complex.calculate_thermal_conductivity(
+        rel_delta_T=1e-8
+    )
+
+    assert np.isfinite(wide_step)
+    assert wide_step > 0
+    assert narrow_step == wide_step
+
+
 @pytest.mark.parametrize(
     "T, P, result, tol",
     [

--- a/tests/test_mixture_without_electrons.py
+++ b/tests/test_mixture_without_electrons.py
@@ -86,11 +86,11 @@ def test_density_complex(mixture_complex, x0, result, tol):
 @pytest.mark.parametrize(
     "T, P, result, tol",
     [
-        (MID_T, MID_P, 3741.395, 1e-2),
+        (MID_T, MID_P, 3741.389, 1e-2),
         (LOW_T, LOW_P, 1143.126, 1e-2),
-        (HIGH_T, LOW_P, 1742.402, 1e-2),
+        (HIGH_T, LOW_P, 1742.367, 1e-2),
         (LOW_T, HIGH_P, 1143.126, 1e-2),
-        (HIGH_T, HIGH_P, 2451.842, 1e-2),
+        (HIGH_T, HIGH_P, 2451.824, 1e-2),
     ],
 )
 def test_heat_capacity_simple(mixture_simple, T, P, result, tol):

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import minplascalc as mpc
+from minplascalc import units as u
 
 
 @pytest.fixture
@@ -87,4 +88,27 @@ def test_electron_partition_log_temperature_derivative():
 
     assert electron.dlog_total_partition_dT(T, 0.0) == pytest.approx(
         (log_high - log_low) / (2 * delta_T), rel=2e-8
+    )
+
+
+@pytest.mark.parametrize("species_name", ["O2", "O+"])
+@pytest.mark.parametrize("T", [1000.0, 12000.0, 25000.0])
+def test_internal_energy_temperature_derivative(species_name, T):
+    species = mpc.species.from_name(species_name)
+    lowering = 0.0
+    delta_T = T * 1e-5
+    finite_difference = (
+        species.internal_energy(T + delta_T, lowering)
+        - species.internal_energy(T - delta_T, lowering)
+    ) / (2 * delta_T)
+
+    assert species.dinternal_energy_dT(T, lowering) == pytest.approx(
+        finite_difference, rel=2e-8
+    )
+
+
+def test_electron_internal_energy_temperature_derivative():
+    electron = mpc.species.Electron()
+    assert electron.dinternal_energy_dT(12000.0, 0.0) == pytest.approx(
+        1.5 * u.k_b
     )

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import minplascalc as mpc
@@ -49,3 +50,41 @@ def test_monatomic_internal_energy(monatomic_sample_species, T, energy, tol):
 def test_diatomic_internal_energy(diatomic_sample_species, T, energy, tol):
     internal_energy = diatomic_sample_species.internal_energy(T, 0)
     assert internal_energy == pytest.approx(energy, abs=tol)
+
+
+@pytest.mark.parametrize("species_name", ["O2", "O+"])
+@pytest.mark.parametrize("T", [2000.0, 12000.0, 25000.0])
+def test_partition_log_temperature_derivative(species_name, T):
+    species = mpc.species.from_name(species_name)
+    volume = 0.37
+    lowering = 0.0
+    delta_T = T * 1e-5
+
+    log_high = np.log(
+        species.total_partition_function(volume, T + delta_T, lowering)
+    )
+    log_low = np.log(
+        species.total_partition_function(volume, T - delta_T, lowering)
+    )
+    finite_difference = (log_high - log_low) / (2 * delta_T)
+
+    assert species.dlog_total_partition_dT(T, lowering) == pytest.approx(
+        finite_difference, rel=2e-8
+    )
+
+
+def test_electron_partition_log_temperature_derivative():
+    electron = mpc.species.Electron()
+    T = 12000.0
+    delta_T = T * 1e-5
+    volume = 0.37
+    log_high = np.log(
+        electron.total_partition_function(volume, T + delta_T, 0.0)
+    )
+    log_low = np.log(
+        electron.total_partition_function(volume, T - delta_T, 0.0)
+    )
+
+    assert electron.dlog_total_partition_dT(T, 0.0) == pytest.approx(
+        (log_high - log_low) / (2 * delta_T), rel=2e-8
+    )


### PR DESCRIPTION
## Summary

- add analytical temperature derivatives for species partition functions and internal energies
- differentiate the converged Gibbs-equilibrium system implicitly, including reference-energy and ionization-lowering terms
- use the equilibrium tangent in thermal transport instead of finite-difference composition probes
- replace finite-difference heat capacity with an analytical enthalpy derivative
- retain finite differences as independent test oracles and keep the legacy temperature-step arguments for API compatibility
- refresh conductivity baselines for the combined analytical-derivative and corrected-Devoto implementation

This is PR 3 in the productionization stack and is based on #102. It remains independent of the later full-log equilibrium solver.

## Validation

- uv run pytest tests -q: 142 passed
- direct analytical-versus-finite-difference derivative tests are included
- species energy derivatives agree with central differences across 1000-25000 K
- uv run mypy src
- pre-commit passes on every changed file
- just build-docs succeeds with the existing nine warnings
- five-run tutorial-10 Si-C-O transport sweep has an identical checksum to #102
- #102 median: 1.27 s
- this branch median: 0.73 s
- warm transport-sweep speedup over #102: 1.74x
- the recorded heat-capacity benchmark improves from 1.006 s to 0.376 s, or 2.68x